### PR TITLE
New "follow pointer" address argument syntax, error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ It is still rather primitive, but good enough to debug several kinds of common c
 
 `gbd <path to RAM dump> <start address>`
 
+or
+
+`gbd <path to RAM dump> *<pointer to start address>`
+
+For example `gbd ram.bin 0x801B4100` (disassemble from `0x801B4100`) or `gbd ram.bin *0x8012D260` (disassemble from the address found at `0x8012D260`)
+
 Currently, the only way to use `gbd` is by dumping the contents of RDRAM to a file. `AUTO` can be entered in place of a start address to use the default start address.
 
 ## Building

--- a/src/gbd.h
+++ b/src/gbd.h
@@ -1,9 +1,27 @@
 #ifndef GBD_H_
 #define GBD_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
+enum start_addr_strategy
+{
+    USE_GIVEN_START_ADDR,
+    USE_START_ADDR_AT_GIVEN_LOCATION,
+    USE_DEFAULT_START_ADDR
+};
+
+struct analyze_options
+{
+    enum start_addr_strategy start_addr_strat;
+    uint32_t start_addr;
+    uint32_t start_addr_location;
+    bool print_textures;
+    bool print_vertices;
+    bool print_matrices;
+};
+
 int
-analyze_gbi (const char *file_name, uint32_t start_addr, bool print_textures, bool print_vertices, bool print_matrices);
+analyze_gbi (const char *file_name, struct analyze_options options);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@ file_exists (const char *filename) {
 static int
 usage (char *exec_name)
 {
-    printf("Usage: %s [--print-textures] [--print-vertices] [--print-matrices] <file path> <WORK_DISP start>\n", exec_name);
+    printf("Usage: %s [--print-textures] [--print-vertices] [--print-matrices] <file path> <WORK_DISP start | *ptr to WORK_DISP start>\n", exec_name);
     return -1;
 }
 


### PR DESCRIPTION
Add ability to follow a pointer to find the start address
(and add some error messages and refactor options)

In oot this would make using gbd easier:
1) make `sPrevTaskWorkBuffer` a non static global
```c
diff --git a/src/code/graph.c b/src/code/graph.c
index 3d53f891c..d3a3a015c 100644
--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -148,8 +148,8 @@ void Graph_Destroy(GraphicsContext* gfxCtx) {
     Fault_RemoveClient(&sGraphFaultClient);
 }
 
+Gfx* sPrevTaskWorkBuffer = NULL;
 void Graph_TaskSet00(GraphicsContext* gfxCtx) {
-    static Gfx* sPrevTaskWorkBuffer = NULL;
     static s32 sGraphCfbInfoIdx = 0;
 
     OSTime timeNow;
```
2) build
3) get the address of `sPrevTaskWorkBuffer`
```
$ ./sym_info.py sPrevTaskWorkBuffer
Symbol 'sPrevTaskWorkBuffer' (VRAM: 0x8012D180, VROM: 0xBA4430, SIZE: 0x10, build/src/code/graph.o)
```
4) pass this address to gbd along with the ram dump using the syntax I added: `gbd rdram.bin *0x8012D180` (the `*`, like for dereferencing pointers in C)

----------

Here's a test.bin with the following contents:
[test.bin.zip](https://github.com/Thar0/gbd/files/12363089/test.bin.zip)
```c
GARBAGE(1);

Gfx data_dlist[] = {
    {0xDF000000, 0},
};

GARBAGE(2);

void *data_ptr = data_dlist;

GARBAGE(3);
```
```
                0x80000000                _garbage1
                0x80000008                data_dlist
                0x80000010                _garbage2
                0x80000018                data_ptr
                0x8000001c                _garbage3
```

the dlist is at 0x8:
```
$ ../build/gbd test.bin 0x8
Analyzing from start address 0x00000008
  /*      0 00000008 */  gsSPEndDisplayList(),
Graphics Task completed without error.
```
and a pointer to the dlist can be found at 0x80000018:
```
$ ../build/gbd test.bin *0x18
Analyzing from start address 0x00000008
  /*      0 00000008 */  gsSPEndDisplayList(),
Graphics Task completed without error.
```