### PR TITLE
Allow passing a pointer to read the start address at

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ It is still rather primitive, but good enough to debug several kinds of common c
 
 `gbd <path to RAM dump> <start address>`
 
+or
+
+`gbd <path to RAM dump> *<pointer to start address>`
+
+For example `gbd ram.bin 0x801B4100` (disassemble from `0x801B4100`) or `gbd ram.bin *0x8012D260` (disassemble from the address found at `0x8012D260`)
+
 Currently, the only way to use `gbd` is by dumping the contents of RDRAM to a file. `AUTO` can be entered in place of a start address to use the default start address.
 
 ## Building

--- a/src/gbd.c
+++ b/src/gbd.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -4289,7 +4290,7 @@ input_callback (void *buf, int count)
 
 int
 analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts, rdram_interface_t *rdram,
-             const void *rdram_arg, uint32_t start_addr, uint32_t auto_start_ptr_addr)
+             const void *rdram_arg, struct start_location_info *start_location)
 {
     gfx_state_t state = {
         .task_done = false,
@@ -4333,15 +4334,24 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
         goto err;
     }
 
-    if (start_addr == 0xFFFFFFFF)
+    uint32_t start_addr = -1U;
+    switch (start_location->type)
     {
-        uint32_t auto_start_addr;
-        if (!state.rdram->read_at(&auto_start_addr, auto_start_ptr_addr & ~KSEG_MASK, sizeof(uint32_t)))
-        {
-            fprintf(print_out, ERROR_COLOR "FAILED to read auto start pointer\n");
+        case USE_START_ADDR_AT_POINTER: {
+            uint32_t auto_start_addr;
+            if (!state.rdram->read_at(&auto_start_addr, start_location->start_location_ptr & ~KSEG_MASK, sizeof(uint32_t)))
+            {
+                fprintf(print_out, ERROR_COLOR "FAILED to read start address from pointer 0x%08" PRIx32 "\n", start_location->start_location_ptr);
+                goto err;
+            }
+            start_addr = BSWAP32(auto_start_addr);
+        } break;
+        case USE_GIVEN_START_ADDR: {
+            start_addr = start_location->start_location;
+        } break;
+        default:
+            fprintf(print_out, ERROR_COLOR "FAILED to get start address, unknown type %d\n", (int)start_location->type);
             goto err;
-        }
-        start_addr = BSWAP32(auto_start_addr);
     }
     start_addr &= ~KSEG_MASK;
     if (!state.rdram->seek(start_addr))

--- a/src/gbd.h
+++ b/src/gbd.h
@@ -26,8 +26,21 @@ typedef struct
     int line;
 } gbd_options_t;
 
+enum start_location_type
+{
+    USE_GIVEN_START_ADDR,
+    USE_START_ADDR_AT_POINTER
+};
+
+struct start_location_info
+{
+    enum start_location_type type;
+    uint32_t start_location;
+    uint32_t start_location_ptr;
+};
+
 int
 analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts, rdram_interface_t *rdram,
-             const void *rdram_arg, uint32_t start_addr, uint32_t auto_start_ptr_addr);
+             const void *rdram_arg, struct start_location_info *start_location);
 
 #endif


### PR DESCRIPTION
#2 redone on top of v2

Below is copied from #2

-------

Add ability to follow a pointer to find the start address

In oot this would make using gbd easier:
1) make `sPrevTaskWorkBuffer` a non static global
```c
diff --git a/src/code/graph.c b/src/code/graph.c
index 3d53f891c..d3a3a015c 100644
--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -148,8 +148,8 @@ void Graph_Destroy(GraphicsContext* gfxCtx) {
     Fault_RemoveClient(&sGraphFaultClient);
 }
 
+Gfx* sPrevTaskWorkBuffer = NULL;
 void Graph_TaskSet00(GraphicsContext* gfxCtx) {
-    static Gfx* sPrevTaskWorkBuffer = NULL;
     static s32 sGraphCfbInfoIdx = 0;
 
     OSTime timeNow;
```
2) build
3) get the address of `sPrevTaskWorkBuffer`
```
$ ./sym_info.py sPrevTaskWorkBuffer
Symbol 'sPrevTaskWorkBuffer' (VRAM: 0x8012D180, VROM: 0xBA4430, SIZE: 0x10, build/src/code/graph.o)
```
4) pass this address to gbd along with the ram dump using the syntax I added: `gbd rdram.bin *0x8012D180` (the `*`, like for dereferencing pointers in C)