### PR TITLE
clangformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 0
+ReflowComments: false
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveMacros: Consecutive
+IndentCaseLabels: true
+SortIncludes: Never
+IndentPPDirectives: AfterHash

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Currently, the only way to use `gbd` is by dumping the contents of RDRAM to a fi
 Run `make` to build the program. Building requires [libiconv](https://www.gnu.org/software/libiconv/) be installed with `--enable-static`. Either install it yourself or run `make libiconv` to install it to `/usr/local/lib`. If you would like to install libiconv elsewhere you can override `ICONV_PREFIX` in the Makefile.
 
 Building for windows is also supported. The steps are the same, merely add `TARGET=windows` in the make commands. If running `make libiconv` for windows, it will be installed locally to the gitignored `libiconv-win` directory.
+
+## Formatting
+
+This project uses clang-format, with configuration in `.clang-format`.

--- a/src/gbd.c
+++ b/src/gbd.c
@@ -15,15 +15,14 @@
 #include "vt.h"
 
 #ifdef WINDOWS
-# include "libiconv-win/include/iconv.h"
+#    include "libiconv-win/include/iconv.h"
 #else
-# include <iconv.h>
+#    include <iconv.h>
 #endif
 
 #define KSEG_MASK (0b111 << 29)
 
-struct bl_conf
-{
+struct bl_conf {
     // Cycle 1
     int m1a_c1;
     int m1b_c1;
@@ -37,8 +36,7 @@ struct bl_conf
 };
 
 static void
-bl_decode (struct bl_conf *out, uint32_t rm)
-{
+bl_decode(struct bl_conf *out, uint32_t rm) {
     out->m1a_c1 = (rm >> 0x1E) & 3;
     out->m1b_c1 = (rm >> 0x1A) & 3;
     out->m2a_c1 = (rm >> 0x16) & 3;
@@ -50,8 +48,7 @@ bl_decode (struct bl_conf *out, uint32_t rm)
     out->m2b_c2 = (rm >> 0x10) & 3;
 }
 
-struct cc_conf
-{
+struct cc_conf {
     // cycle 1 rgb
     uint8_t a0;
     uint8_t b0;
@@ -75,14 +72,13 @@ struct cc_conf
 };
 
 static void
-cc_decode (struct cc_conf *out, uint32_t hi, uint32_t lo)
-{
+cc_decode(struct cc_conf *out, uint32_t hi, uint32_t lo) {
     out->a0  = SHIFTR(hi, 4, 20);
     out->c0  = SHIFTR(hi, 5, 15);
     out->Aa0 = SHIFTR(hi, 3, 12);
-    out->Ac0 = SHIFTR(hi, 3,  9);
-    out->a1  = SHIFTR(hi, 4,  5);
-    out->c1  = SHIFTR(hi, 5,  0);
+    out->Ac0 = SHIFTR(hi, 3, 9);
+    out->a1  = SHIFTR(hi, 4, 5);
+    out->c1  = SHIFTR(hi, 5, 0);
 
     out->b0  = SHIFTR(lo, 4, 28);
     out->b1  = SHIFTR(lo, 4, 24);
@@ -90,31 +86,31 @@ cc_decode (struct cc_conf *out, uint32_t hi, uint32_t lo)
     out->Ac1 = SHIFTR(lo, 3, 18);
     out->d0  = SHIFTR(lo, 3, 15);
     out->Ab0 = SHIFTR(lo, 3, 12);
-    out->Ad0 = SHIFTR(lo, 3,  9);
-    out->d1  = SHIFTR(lo, 3,  6);
-    out->Ab1 = SHIFTR(lo, 3,  3);
-    out->Ad1 = SHIFTR(lo, 3,  0);
+    out->Ad0 = SHIFTR(lo, 3, 9);
+    out->d1  = SHIFTR(lo, 3, 6);
+    out->Ab1 = SHIFTR(lo, 3, 3);
+    out->Ad1 = SHIFTR(lo, 3, 0);
 }
 
 typedef struct
 {
     // gDPSetTile
-    int fmt;            /* texture image format */
-    int siz;            /* pixel size */
-    int line;           /* Size of one row (s) of the texture tile (9-bit) */
-    uint16_t tmem;      /* tmem address of texture tile origin (9-bit) */
-    int palette;        /* position of palette for 4-bit CI (4-bit) */
-    unsigned cms;       /* s-axis flags */
-    unsigned cmt;       /* t-axis flags */
-    int masks;          /* s-axis mask */
-    int maskt;          /* t-axis mask */
-    int shifts;         /* s-axis shift */
-    int shiftt;         /* t-axis shift */
+    int fmt;       /* texture image format */
+    int siz;       /* pixel size */
+    int line;      /* Size of one row (s) of the texture tile (9-bit) */
+    uint16_t tmem; /* tmem address of texture tile origin (9-bit) */
+    int palette;   /* position of palette for 4-bit CI (4-bit) */
+    unsigned cms;  /* s-axis flags */
+    unsigned cmt;  /* t-axis flags */
+    int masks;     /* s-axis mask */
+    int maskt;     /* t-axis mask */
+    int shifts;    /* s-axis shift */
+    int shiftt;    /* t-axis shift */
     // gDPSetTileSize
-    qu102_t uls;        /* tile upper-left s-coordinate */
-    qu102_t ult;        /* tile upper-left t-coordinate */
-    qu102_t lrs;        /* tile lower-right s-coordinate */
-    qu102_t lrt;        /* tile lower-right t-coordinate */
+    qu102_t uls; /* tile upper-left s-coordinate */
+    qu102_t ult; /* tile upper-left t-coordinate */
+    qu102_t lrs; /* tile lower-right s-coordinate */
+    qu102_t lrt; /* tile lower-right t-coordinate */
 } tile_descriptor_t;
 
 typedef struct {
@@ -215,21 +211,20 @@ typedef struct
     rdram_interface_t *rdram;
 } gfx_state_t;
 
-#define CLIP_NEGX   (1 << 0)
-#define CLIP_POSX   (1 << 1)
-#define CLIP_X      (CLIP_NEGX | CLIP_POSX)
-#define CLIP_NEGY   (1 << 2)
-#define CLIP_POSY   (1 << 3)
-#define CLIP_Y      (CLIP_NEGY | CLIP_POSY)
-#define CLIP_W      (1 << 4)
-#define CLIP_ALL    (CLIP_NEGX | CLIP_POSX | CLIP_NEGY | CLIP_POSY | CLIP_W)
+#define CLIP_NEGX (1 << 0)
+#define CLIP_POSX (1 << 1)
+#define CLIP_X    (CLIP_NEGX | CLIP_POSX)
+#define CLIP_NEGY (1 << 2)
+#define CLIP_POSY (1 << 3)
+#define CLIP_Y    (CLIP_NEGY | CLIP_POSY)
+#define CLIP_W    (1 << 4)
+#define CLIP_ALL  (CLIP_NEGX | CLIP_POSX | CLIP_NEGY | CLIP_POSY | CLIP_W)
 
 #define OTHERMODE_VAL(state, hi_lo, field) \
     ((state)->othermode_##hi_lo & MDMASK(field))
 
 static inline tile_descriptor_t *
-get_tile_desc (gfx_state_t *state, int tile)
-{
+get_tile_desc(gfx_state_t *state, int tile) {
     if ((unsigned)tile >= ARRAY_COUNT(state->tile_descriptors)) {
         // invalid tile descriptor
         return NULL;
@@ -242,30 +237,29 @@ get_tile_desc (gfx_state_t *state, int tile)
     GW_##id,
 #define DEFINE_ERROR(id, string) \
     GW_##id,
-enum gbi_warning
-{
+enum gbi_warning {
 #include "warnings_errors.h"
 };
 #undef DEFINE_WARNING
 #undef DEFINE_ERROR
 
 #define DEFINE_WARNING(id, string) \
-    [ GW_##id ] = string,
+    [GW_##id] = string,
 #define DEFINE_ERROR(id, string) \
-    [ GW_##id ] = string,
-static const char * const warn_strings[] =
-{
+    [GW_##id] = string,
+static const char *const warn_strings[] =
+    {
 #include "warnings_errors.h"
 };
 #undef DEFINE_WARNING
 #undef DEFINE_ERROR
 
 #define DEFINE_WARNING(id, string) \
-    [ GW_##id ] = false,
+    [GW_##id] = false,
 #define DEFINE_ERROR(id, string) \
-    [ GW_##id ] = true,
+    [GW_##id] = true,
 static const uint8_t warn_is_error[] =
-{
+    {
 #include "warnings_errors.h"
 };
 #undef DEFINE_WARNING
@@ -273,31 +267,29 @@ static const uint8_t warn_is_error[] =
 
 // collections of warnings
 
-enum gbi_warning_classes
-{
+enum gbi_warning_classes {
     GWC_MISSING_SYNCS,
 
 };
 static enum gbi_warning warn_classes[][8] =
-{
-    [GWC_MISSING_SYNCS] = { GW_MISSING_PIPESYNC, GW_MISSING_LOADSYNC, GW_MISSING_TILESYNC },
+    {
+        [GWC_MISSING_SYNCS] = {GW_MISSING_PIPESYNC, GW_MISSING_LOADSYNC, GW_MISSING_TILESYNC},
 };
 
 // warning flags
 
-static const char * const warn_flags[] =
-{
-    [GWC_MISSING_SYNCS] = "missing-syncs",
+static const char *const warn_flags[] =
+    {
+        [GWC_MISSING_SYNCS] = "missing-syncs",
 
 };
 
 typedef int (*print_fn)(const char *fmt, ...);
 typedef int (*fprint_fn)(FILE *file, const char *fmt, ...);
-typedef int (*vprint_fn)(const char*fmt, va_list args);
+typedef int (*vprint_fn)(const char *fmt, va_list args);
 
 static inline void
-_Vprint (vprint_fn vpfn, const char *fmt, ...)
-{
+_Vprint(vprint_fn vpfn, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
@@ -319,13 +311,11 @@ error: <desc>
     <explanation if verbose?>
 */
 
-#define ERROR_COLOR     VT_RGBFCOL(232,  56,  40)
-#define WARNING_COLOR   VT_RGBFCOL(180,   0, 160)
-#define NOTE_COLOR      VT_RGBFCOL( 96, 216, 216)
+#define ERROR_COLOR   VT_RGBFCOL(232, 56, 40)
+#define WARNING_COLOR VT_RGBFCOL(180, 0, 160)
+#define NOTE_COLOR    VT_RGBFCOL(96, 216, 216)
 
-void
-Note (vprint_fn vpfn, const char *fmt, ...)
-{
+void Note(vprint_fn vpfn, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
@@ -339,18 +329,14 @@ Note (vprint_fn vpfn, const char *fmt, ...)
 // TODO enabling/disabling warnings
 #define warning_disabled(id) false
 
-void
-Warning_Error (gfx_state_t *state, vprint_fn vpfn, enum gbi_warning warn_id, const char *fmt, ...)
-{
+void Warning_Error(gfx_state_t *state, vprint_fn vpfn, enum gbi_warning warn_id, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
     bool err = warn_is_error[warn_id];
 
-    if (err || !warning_disabled(warn_id))
-    {
-        if (state->multi_packet)
-        {
+    if (err || !warning_disabled(warn_id)) {
+        if (state->multi_packet) {
             Note(vpfn, "In expansion of macro '%s':", state->multi_packet_name);
             _Vprint(vpfn, "  ");
         }
@@ -373,17 +359,14 @@ Warning_Error (gfx_state_t *state, vprint_fn vpfn, enum gbi_warning warn_id, con
     (cond) ? (void)0 : WARNING_ERROR(state, reason, ##__VA_ARGS__)
 
 static inline int
-sign_extend (int v, int n)
-{
-    unsigned mask = (1 << (n-1)) - 1;
-    unsigned sgnbit = (1 << (n-1));
+sign_extend(int v, int n) {
+    unsigned mask   = (1 << (n - 1)) - 1;
+    unsigned sgnbit = (1 << (n - 1));
 
     return (v & mask) - (v & sgnbit);
 }
 
-int
-gfx_fprintf_wrapper (FILE *file, const char *fmt, ...)
-{
+int gfx_fprintf_wrapper(FILE *file, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
@@ -393,9 +376,7 @@ gfx_fprintf_wrapper (FILE *file, const char *fmt, ...)
     return ret;
 }
 
-void
-print_string (gfx_state_t *state, uint32_t str_addr, fprint_fn pfn, FILE *file)
-{
+void print_string(gfx_state_t *state, uint32_t str_addr, fprint_fn pfn, FILE *file) {
     iconv_t cd;
     char c;
     char *in_buf, *out_buf, *iconv_in_buf, *iconv_out_buf;
@@ -414,7 +395,7 @@ print_string (gfx_state_t *state, uint32_t str_addr, fprint_fn pfn, FILE *file)
     pfn(file, "\"");
 
     /* read the whole string */
-    in_buf = malloc(sizeof(char) * str_len);
+    in_buf  = malloc(sizeof(char) * str_len);
     out_buf = malloc(sizeof(wchar_t) * str_len);
 
     state->rdram->seek(str_addr);
@@ -424,10 +405,10 @@ print_string (gfx_state_t *state, uint32_t str_addr, fprint_fn pfn, FILE *file)
     /* convert string from EUC-JP to UTF-8 */
     cd = iconv_open("UTF-8", "EUC-JP");
 
-    in_bytes_left = str_len;
+    in_bytes_left  = str_len;
     out_bytes_left = 2 * str_len;
-    iconv_in_buf = in_buf;
-    iconv_out_buf = out_buf;
+    iconv_in_buf   = in_buf;
+    iconv_out_buf  = out_buf;
     iconv(cd, &iconv_in_buf, &in_bytes_left, &iconv_out_buf, &out_bytes_left);
     iconv_close(cd);
 
@@ -442,31 +423,28 @@ err:
     free(out_buf);
 }
 
-int
-print_light (FILE *print_out, gfx_state_t *state, uint32_t lights_addr, int count)
-{
+int print_light(FILE *print_out, gfx_state_t *state, uint32_t lights_addr, int count) {
     Lightsn lights;
 
     if (!state->rdram->read_at(&lights, lights_addr, sizeof(Ambient) + count * sizeof(Light)))
         goto err;
 
     fprintf(print_out, "(Ambient){\n");
-    fprintf(print_out, "    .col  = { %3d, %3d, %3d },\n", lights.a.l.col[0],  lights.a.l.col[1],  lights.a.l.col[2]);
+    fprintf(print_out, "    .col  = { %3d, %3d, %3d },\n", lights.a.l.col[0], lights.a.l.col[1], lights.a.l.col[2]);
     fprintf(print_out, "    .colc = { %3d, %3d, %3d },\n", lights.a.l.colc[0], lights.a.l.colc[1], lights.a.l.colc[2]);
     fprintf(print_out, "},\n");
 
     fprintf(print_out, "/* Lights%d */\n", count);
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         fprintf(print_out, "(Light){\n");
         fprintf(print_out, "    .col  = { %3d, %3d, %3d },\n",
-                lights.l[i].l.col[0],  lights.l[i].l.col[1],  lights.l[i].l.col[2]);
+                lights.l[i].l.col[0], lights.l[i].l.col[1], lights.l[i].l.col[2]);
         fprintf(print_out, "    .pad1 = %d,\n", lights.l[i].l.pad1);
         fprintf(print_out, "    .colc = { %3d, %3d, %3d },\n",
                 lights.l[i].l.colc[0], lights.l[i].l.colc[1], lights.l[i].l.colc[2]);
         fprintf(print_out, "    .pad2 = %d,\n", lights.l[i].l.pad2);
         fprintf(print_out, "    .dir  = { %3d, %3d, %3d },\n",
-                lights.l[i].l.dir[0],  lights.l[i].l.dir[1],  lights.l[i].l.dir[2]);
+                lights.l[i].l.dir[0], lights.l[i].l.dir[1], lights.l[i].l.dir[2]);
         fprintf(print_out, "    .pad3 = %d,\n", lights.l[i].l.pad3);
         fprintf(print_out, "},\n");
     }
@@ -478,101 +456,130 @@ err:
 }
 
 static const char *
-cc_str (unsigned int v, int i)
-{
-    switch (i)
-    {
+cc_str(unsigned int v, int i) {
+    switch (i) {
         case 0: /* CC 1 A */
         case 8: /* CC 2 A */
-            {
-                static const char *cc1a[] =
-                    {
-                        "COMBINED", "TEXEL0", "TEXEL1", "PRIMITIVE",
-                        "SHADE", "ENVIRONMENT", "1", "NOISE",
-                    };
-                if (v >= ARRAY_COUNT(cc1a))
-                    return "0";
-                return cc1a[v];
-            }
-            break;
+        {
+            static const char *cc1a[] =
+                {
+                    "COMBINED",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMITIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "1",
+                    "NOISE",
+                };
+            if (v >= ARRAY_COUNT(cc1a))
+                return "0";
+            return cc1a[v];
+        } break;
         case 1: /* CC 1 B */
         case 9: /* CC 2 B */
-            {
-                static const char *cc1b[] =
-                    {
-                        "COMBINED", "TEXEL0", "TEXEL1", "PRIMITIVE",
-                        "SHADE", "ENVIRONMENT", "CENTER", "K4",
-                    };
-                if (v >= ARRAY_COUNT(cc1b))
-                    return "0";
-                return cc1b[v];
-            }
-            break;
-        case  2: /* CC 1 C */
+        {
+            static const char *cc1b[] =
+                {
+                    "COMBINED",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMITIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "CENTER",
+                    "K4",
+                };
+            if (v >= ARRAY_COUNT(cc1b))
+                return "0";
+            return cc1b[v];
+        } break;
+        case 2:  /* CC 1 C */
         case 10: /* CC 2 C */
-            {
-                static const char *cc1c[] =
-                    {
-                        "COMBINED", "TEXEL0", "TEXEL1", "PRIMiTIVE",
-                        "SHADE", "ENVIRONMENT", "CENTER", "COMBINED_ALPHA",
-                        "TEXEL0_ALPHA", "TEXEL1_ALPHA", "PRIMITIVE_ALPHA", "SHADE_ALPHA",
-                        "ENV_ALPHA", "LOD_FRACTION", "PRIM_LOD_FRAC", "K5",
-                    };
-                if (v >= ARRAY_COUNT(cc1c))
-                    return "0";
-                return cc1c[v];
-            }
-            break;
-        case  3: /* CC 1 D */
+        {
+            static const char *cc1c[] =
+                {
+                    "COMBINED",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMiTIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "CENTER",
+                    "COMBINED_ALPHA",
+                    "TEXEL0_ALPHA",
+                    "TEXEL1_ALPHA",
+                    "PRIMITIVE_ALPHA",
+                    "SHADE_ALPHA",
+                    "ENV_ALPHA",
+                    "LOD_FRACTION",
+                    "PRIM_LOD_FRAC",
+                    "K5",
+                };
+            if (v >= ARRAY_COUNT(cc1c))
+                return "0";
+            return cc1c[v];
+        } break;
+        case 3:  /* CC 1 D */
         case 11: /* CC 2 D */
-            {
-                static const char *cc1d[] =
-                    {
-                        "COMBINED", "TEXEL0", "TEXEL1", "PRIMITIVE",
-                        "SHADE", "ENVIRONMENT", "1",
-                    };
-                if (v >= ARRAY_COUNT(cc1d))
-                    return "0";
-                return cc1d[v];
-            }
-            break;
+        {
+            static const char *cc1d[] =
+                {
+                    "COMBINED",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMITIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "1",
+                };
+            if (v >= ARRAY_COUNT(cc1d))
+                return "0";
+            return cc1d[v];
+        } break;
         case 4:  /* AC 1 A */
         case 12: /* AC 2 A */
         case 5:  /* AC 1 B */
         case 13: /* AC 2 B */
         case 7:  /* AC 1 D */
         case 15: /* AC 2 D */
-            {
-                static const char *ac1abd[] =
-                    {
-                        "COMBINED", "TEXEL0", "TEXEL1", "PRIMITIVE",
-                        "SHADE", "ENVIRONMENT", "1",
-                    };
-                if (v >= ARRAY_COUNT(ac1abd))
-                    return "0";
-                return ac1abd[v];
-            }
-            break;
+        {
+            static const char *ac1abd[] =
+                {
+                    "COMBINED",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMITIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "1",
+                };
+            if (v >= ARRAY_COUNT(ac1abd))
+                return "0";
+            return ac1abd[v];
+        } break;
         case 6:  /* AC 1 C */
         case 14: /* AC 2 C */
-            {
-                static const char *ac1c[] =
-                    {
-                        "LOD_FRACTION", "TEXEL0", "TEXEL1", "PRIMITIVE",
-                        "SHADE", "ENVIRONMENT", "PRIM_LOD_FRAC",
-                    };
-                if (v >= ARRAY_COUNT(ac1c))
-                    return "0";
-                return ac1c[v];
-            }
-            break;
+        {
+            static const char *ac1c[] =
+                {
+                    "LOD_FRACTION",
+                    "TEXEL0",
+                    "TEXEL1",
+                    "PRIMITIVE",
+                    "SHADE",
+                    "ENVIRONMENT",
+                    "PRIM_LOD_FRAC",
+                };
+            if (v >= ARRAY_COUNT(ac1c))
+                return "0";
+            return ac1c[v];
+        } break;
     }
     return "?";
 }
 
-void
-print_cc (FILE *print_out, uint32_t cc_hi, uint32_t cc_lo)
-{
+void print_cc(FILE *print_out, uint32_t cc_hi, uint32_t cc_lo) {
     fprintf(print_out, "%s, %s, %s, %s, "
                        "%s, %s, %s, %s, "
                        "%s, %s, %s, %s, "
@@ -583,35 +590,38 @@ print_cc (FILE *print_out, uint32_t cc_hi, uint32_t cc_lo)
             cc_str(SHIFTR(cc_lo, 3, 15), 3),
             cc_str(SHIFTR(cc_hi, 3, 12), 4),
             cc_str(SHIFTR(cc_lo, 3, 12), 5),
-            cc_str(SHIFTR(cc_hi, 3, 9),  6),
-            cc_str(SHIFTR(cc_lo, 3, 9),  7),
-            cc_str(SHIFTR(cc_hi, 4, 5),  8),
+            cc_str(SHIFTR(cc_hi, 3, 9), 6),
+            cc_str(SHIFTR(cc_lo, 3, 9), 7),
+            cc_str(SHIFTR(cc_hi, 4, 5), 8),
             cc_str(SHIFTR(cc_lo, 4, 24), 9),
-            cc_str(SHIFTR(cc_hi, 5, 0),  10),
-            cc_str(SHIFTR(cc_lo, 3, 6),  11),
+            cc_str(SHIFTR(cc_hi, 5, 0), 10),
+            cc_str(SHIFTR(cc_lo, 3, 6), 11),
             cc_str(SHIFTR(cc_lo, 3, 21), 12),
-            cc_str(SHIFTR(cc_lo, 3, 3),  13),
+            cc_str(SHIFTR(cc_lo, 3, 3), 13),
             cc_str(SHIFTR(cc_lo, 3, 18), 14),
-            cc_str(SHIFTR(cc_lo, 3, 0),  15));
+            cc_str(SHIFTR(cc_lo, 3, 0), 15));
 }
 
-void
-print_geometrymode (FILE *print_out, uint32_t geometry_mode)
-{
+void print_geometrymode(FILE *print_out, uint32_t geometry_mode) {
     struct F3DZEX_const geometry_modes[] =
-    {
-        F3DZEX_CONST(G_ZBUFFER),             F3DZEX_CONST(G_TEXTURE_ENABLE),
-        F3DZEX_CONST(G_SHADE),               F3DZEX_CONST(G_SHADING_SMOOTH),
-        F3DZEX_CONST(G_CULL_FRONT),          F3DZEX_CONST(G_CULL_BACK),
-        F3DZEX_CONST(G_FOG),                 F3DZEX_CONST(G_LIGHTING),
-        F3DZEX_CONST(G_TEXTURE_GEN),         F3DZEX_CONST(G_TEXTURE_GEN_LINEAR),
-        F3DZEX_CONST(G_LOD),                 F3DZEX_CONST(G_CLIPPING),
-        F3DZEX_CONST(G_LIGHTING_POSITIONAL),
-    };
+        {
+            F3DZEX_CONST(G_ZBUFFER),
+            F3DZEX_CONST(G_TEXTURE_ENABLE),
+            F3DZEX_CONST(G_SHADE),
+            F3DZEX_CONST(G_SHADING_SMOOTH),
+            F3DZEX_CONST(G_CULL_FRONT),
+            F3DZEX_CONST(G_CULL_BACK),
+            F3DZEX_CONST(G_FOG),
+            F3DZEX_CONST(G_LIGHTING),
+            F3DZEX_CONST(G_TEXTURE_GEN),
+            F3DZEX_CONST(G_TEXTURE_GEN_LINEAR),
+            F3DZEX_CONST(G_LOD),
+            F3DZEX_CONST(G_CLIPPING),
+            F3DZEX_CONST(G_LIGHTING_POSITIONAL),
+        };
     bool first = true;
 
-    for (size_t i = 0; i < ARRAY_COUNT(geometry_modes); i++)
-    {
+    for (size_t i = 0; i < ARRAY_COUNT(geometry_modes); i++) {
         if ((geometry_modes[i].value & geometry_mode) == 0)
             continue;
 
@@ -622,26 +632,26 @@ print_geometrymode (FILE *print_out, uint32_t geometry_mode)
         geometry_mode &= ~geometry_modes[i].value;
         first = false;
     }
-    if (geometry_mode != 0)
-    {
+    if (geometry_mode != 0) {
         if (!first)
             fprintf(print_out, " | ");
         fprintf(print_out, "0x%08X", geometry_mode);
-    }
-    else if (first)
+    } else if (first)
         fprintf(print_out, "0");
 }
 
 static void
-print_othermode_hi (FILE *print_out, uint32_t othermode_hi)
-{
-#define CASE_PRINT(name) \
-    case name : fprintf(print_out, #name); break
-#define DEFAULT_PRINT(name) \
-    default: fprintf(print_out, "0x%08X", othermode_hi & MDMASK(name)); break
+print_othermode_hi(FILE *print_out, uint32_t othermode_hi) {
+#define CASE_PRINT(name)           \
+    case name:                     \
+        fprintf(print_out, #name); \
+        break
+#define DEFAULT_PRINT(name)                                       \
+    default:                                                      \
+        fprintf(print_out, "0x%08X", othermode_hi &MDMASK(name)); \
+        break
 
-    switch (othermode_hi & MDMASK(ALPHADITHER))
-    {
+    switch (othermode_hi & MDMASK(ALPHADITHER)) {
         CASE_PRINT(G_AD_PATTERN);
         CASE_PRINT(G_AD_NOTPATTERN);
         CASE_PRINT(G_AD_NOISE);
@@ -649,8 +659,7 @@ print_othermode_hi (FILE *print_out, uint32_t othermode_hi)
         DEFAULT_PRINT(ALPHADITHER);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(RGBDITHER))
-    {
+    switch (othermode_hi & MDMASK(RGBDITHER)) {
         CASE_PRINT(G_CD_MAGICSQ);
         CASE_PRINT(G_CD_BAYER);
         CASE_PRINT(G_CD_NOISE);
@@ -658,61 +667,53 @@ print_othermode_hi (FILE *print_out, uint32_t othermode_hi)
         DEFAULT_PRINT(RGBDITHER);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(COMBKEY))
-    {
+    switch (othermode_hi & MDMASK(COMBKEY)) {
         CASE_PRINT(G_CK_NONE);
         CASE_PRINT(G_CK_KEY);
         DEFAULT_PRINT(COMBKEY);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTCONV))
-    {
+    switch (othermode_hi & MDMASK(TEXTCONV)) {
         CASE_PRINT(G_TC_CONV);
         CASE_PRINT(G_TC_FILTCONV);
         CASE_PRINT(G_TC_FILT);
         DEFAULT_PRINT(TEXTCONV);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTFILT))
-    {
+    switch (othermode_hi & MDMASK(TEXTFILT)) {
         CASE_PRINT(G_TF_POINT);
         CASE_PRINT(G_TF_BILERP);
         CASE_PRINT(G_TF_AVERAGE);
         DEFAULT_PRINT(TEXTFILT);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTLUT))
-    {
+    switch (othermode_hi & MDMASK(TEXTLUT)) {
         CASE_PRINT(G_TT_NONE);
         CASE_PRINT(G_TT_RGBA16);
         CASE_PRINT(G_TT_IA16);
         DEFAULT_PRINT(TEXTLUT);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTLOD))
-    {
+    switch (othermode_hi & MDMASK(TEXTLOD)) {
         CASE_PRINT(G_TL_TILE);
         CASE_PRINT(G_TL_LOD);
         DEFAULT_PRINT(TEXTLOD);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTDETAIL))
-    {
+    switch (othermode_hi & MDMASK(TEXTDETAIL)) {
         CASE_PRINT(G_TD_CLAMP);
         CASE_PRINT(G_TD_SHARPEN);
         CASE_PRINT(G_TD_DETAIL);
         DEFAULT_PRINT(TEXTDETAIL);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(TEXTPERSP))
-    {
+    switch (othermode_hi & MDMASK(TEXTPERSP)) {
         CASE_PRINT(G_TP_NONE);
         CASE_PRINT(G_TP_PERSP);
         DEFAULT_PRINT(TEXTPERSP);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(CYCLETYPE))
-    {
+    switch (othermode_hi & MDMASK(CYCLETYPE)) {
         CASE_PRINT(G_CYC_1CYCLE);
         CASE_PRINT(G_CYC_2CYCLE);
         CASE_PRINT(G_CYC_COPY);
@@ -720,17 +721,13 @@ print_othermode_hi (FILE *print_out, uint32_t othermode_hi)
         DEFAULT_PRINT(CYCLETYPE);
     }
     fprintf(print_out, " | ");
-    switch (othermode_hi & MDMASK(PIPELINE))
-    {
+    switch (othermode_hi & MDMASK(PIPELINE)) {
         CASE_PRINT(G_PM_NPRIMITIVE);
         CASE_PRINT(G_PM_1PRIMITIVE);
         DEFAULT_PRINT(PIPELINE);
     }
-    uint32_t unk_mask = ~(MDMASK(ALPHADITHER) | MDMASK(RGBDITHER) | MDMASK(COMBKEY) | MDMASK(TEXTCONV)
-                        | MDMASK(TEXTFILT) | MDMASK(TEXTLUT) | MDMASK(TEXTLOD) | MDMASK(TEXTDETAIL)
-                        | MDMASK(TEXTPERSP) | MDMASK(CYCLETYPE) | MDMASK(PIPELINE));
-    if (othermode_hi & unk_mask)
-    {
+    uint32_t unk_mask = ~(MDMASK(ALPHADITHER) | MDMASK(RGBDITHER) | MDMASK(COMBKEY) | MDMASK(TEXTCONV) | MDMASK(TEXTFILT) | MDMASK(TEXTLUT) | MDMASK(TEXTLOD) | MDMASK(TEXTDETAIL) | MDMASK(TEXTPERSP) | MDMASK(CYCLETYPE) | MDMASK(PIPELINE));
+    if (othermode_hi & unk_mask) {
         fprintf(print_out, "| 0x%08X", othermode_hi & unk_mask);
     }
 #undef CASE_PRINT
@@ -738,36 +735,31 @@ print_othermode_hi (FILE *print_out, uint32_t othermode_hi)
 }
 
 static int
-print_rm_mode (FILE *print_out, uint32_t arg)
-{
+print_rm_mode(FILE *print_out, uint32_t arg) {
     int n = 0;
 
     if (arg & AA_EN)
         n += fprintf(print_out, "AA_EN");
 
-    if (arg & Z_CMP)
-    {
+    if (arg & Z_CMP) {
         if (n > 0)
             n += fprintf(print_out, " | ");
         n += fprintf(print_out, "Z_CMP");
     }
 
-    if (arg & Z_UPD)
-    {
+    if (arg & Z_UPD) {
         if (n > 0)
             n += fprintf(print_out, " | ");
         n += fprintf(print_out, "Z_UPD");
     }
 
-    if (arg & IM_RD)
-    {
+    if (arg & IM_RD) {
         if (n > 0)
             n += fprintf(print_out, " | ");
         n += fprintf(print_out, "IM_RD");
     }
 
-    if (arg & CLR_ON_CVG)
-    {
+    if (arg & CLR_ON_CVG) {
         if (n > 0)
             n += fprintf(print_out, " | ");
         n += fprintf(print_out, "CLR_ON_CVG");
@@ -776,19 +768,33 @@ print_rm_mode (FILE *print_out, uint32_t arg)
     if (n > 0)
         n += fprintf(print_out, " | ");
 
-    switch (arg & 0x00000300)
-    {
-        case CVG_DST_CLAMP: n += fprintf(print_out, "CVG_DST_CLAMP"); break;
-        case CVG_DST_WRAP:  n += fprintf(print_out, "CVG_DST_WRAP");  break;
-        case CVG_DST_FULL:  n += fprintf(print_out, "CVG_DST_FULL");  break;
-        case CVG_DST_SAVE:  n += fprintf(print_out, "CVG_DST_SAVE");  break;
+    switch (arg & 0x00000300) {
+        case CVG_DST_CLAMP:
+            n += fprintf(print_out, "CVG_DST_CLAMP");
+            break;
+        case CVG_DST_WRAP:
+            n += fprintf(print_out, "CVG_DST_WRAP");
+            break;
+        case CVG_DST_FULL:
+            n += fprintf(print_out, "CVG_DST_FULL");
+            break;
+        case CVG_DST_SAVE:
+            n += fprintf(print_out, "CVG_DST_SAVE");
+            break;
     }
-    switch (arg & 0x00000C00)
-    {
-        case ZMODE_OPA:   n += fprintf(print_out, " | ZMODE_OPA"); break;
-        case ZMODE_INTER: n += fprintf(print_out, " | ZMODE_INTER"); break;
-        case ZMODE_XLU:   n += fprintf(print_out, " | ZMODE_XLU"); break;
-        case ZMODE_DEC:   n += fprintf(print_out, " | ZMODE_DEC"); break;
+    switch (arg & 0x00000C00) {
+        case ZMODE_OPA:
+            n += fprintf(print_out, " | ZMODE_OPA");
+            break;
+        case ZMODE_INTER:
+            n += fprintf(print_out, " | ZMODE_INTER");
+            break;
+        case ZMODE_XLU:
+            n += fprintf(print_out, " | ZMODE_XLU");
+            break;
+        case ZMODE_DEC:
+            n += fprintf(print_out, " | ZMODE_DEC");
+            break;
     }
 
     if (arg & CVG_X_ALPHA)
@@ -804,161 +810,186 @@ print_rm_mode (FILE *print_out, uint32_t arg)
 }
 
 static int
-print_rm_cbl (FILE *print_out, uint32_t arg, int c)
-{
+print_rm_cbl(FILE *print_out, uint32_t arg, int c) {
     int n = 0;
     if (c == 2)
         arg <<= 2;
 
-    switch ((arg >> 30) & 0b11)
-    {
-        case G_BL_CLR_IN:  n += fprintf(print_out, "GBL_c%i(G_BL_CLR_IN", c);  break;
-        case G_BL_CLR_MEM: n += fprintf(print_out, "GBL_c%i(G_BL_CLR_MEM", c); break;
-        case G_BL_CLR_BL:  n += fprintf(print_out, "GBL_c%i(G_BL_CLR_BL", c);  break;
-        case G_BL_CLR_FOG: n += fprintf(print_out, "GBL_c%i(G_BL_CLR_FOG", c); break;
+    switch ((arg >> 30) & 0b11) {
+        case G_BL_CLR_IN:
+            n += fprintf(print_out, "GBL_c%i(G_BL_CLR_IN", c);
+            break;
+        case G_BL_CLR_MEM:
+            n += fprintf(print_out, "GBL_c%i(G_BL_CLR_MEM", c);
+            break;
+        case G_BL_CLR_BL:
+            n += fprintf(print_out, "GBL_c%i(G_BL_CLR_BL", c);
+            break;
+        case G_BL_CLR_FOG:
+            n += fprintf(print_out, "GBL_c%i(G_BL_CLR_FOG", c);
+            break;
     }
-    switch ((arg >> 26) & 0b11)
-    {
-        case G_BL_A_IN:    n += fprintf(print_out, ", G_BL_A_IN");    break;
-        case G_BL_A_FOG:   n += fprintf(print_out, ", G_BL_A_FOG");   break;
-        case G_BL_A_SHADE: n += fprintf(print_out, ", G_BL_A_SHADE"); break;
-        case G_BL_0:       n += fprintf(print_out, ", G_BL_0");       break;
+    switch ((arg >> 26) & 0b11) {
+        case G_BL_A_IN:
+            n += fprintf(print_out, ", G_BL_A_IN");
+            break;
+        case G_BL_A_FOG:
+            n += fprintf(print_out, ", G_BL_A_FOG");
+            break;
+        case G_BL_A_SHADE:
+            n += fprintf(print_out, ", G_BL_A_SHADE");
+            break;
+        case G_BL_0:
+            n += fprintf(print_out, ", G_BL_0");
+            break;
     }
-    switch ((arg >> 22) & 0b11)
-    {
-        case G_BL_CLR_IN:  n += fprintf(print_out, ", G_BL_CLR_IN");  break;
-        case G_BL_CLR_MEM: n += fprintf(print_out, ", G_BL_CLR_MEM"); break;
-        case G_BL_CLR_BL:  n += fprintf(print_out, ", G_BL_CLR_BL");  break;
-        case G_BL_CLR_FOG: n += fprintf(print_out, ", G_BL_CLR_FOG"); break;
+    switch ((arg >> 22) & 0b11) {
+        case G_BL_CLR_IN:
+            n += fprintf(print_out, ", G_BL_CLR_IN");
+            break;
+        case G_BL_CLR_MEM:
+            n += fprintf(print_out, ", G_BL_CLR_MEM");
+            break;
+        case G_BL_CLR_BL:
+            n += fprintf(print_out, ", G_BL_CLR_BL");
+            break;
+        case G_BL_CLR_FOG:
+            n += fprintf(print_out, ", G_BL_CLR_FOG");
+            break;
     }
-    switch ((arg >> 18) & 0b11)
-    {
-        case G_BL_1MA:   n += fprintf(print_out, ", G_BL_1MA)");   break;
-        case G_BL_A_MEM: n += fprintf(print_out, ", G_BL_A_MEM)"); break;
-        case G_BL_1:     n += fprintf(print_out, ", G_BL_1)");     break;
-        case G_BL_0:     n += fprintf(print_out, ", G_BL_0)");     break;
+    switch ((arg >> 18) & 0b11) {
+        case G_BL_1MA:
+            n += fprintf(print_out, ", G_BL_1MA)");
+            break;
+        case G_BL_A_MEM:
+            n += fprintf(print_out, ", G_BL_A_MEM)");
+            break;
+        case G_BL_1:
+            n += fprintf(print_out, ", G_BL_1)");
+            break;
+        case G_BL_0:
+            n += fprintf(print_out, ", G_BL_0)");
+            break;
     }
     return n;
 }
 
 static void
-print_othermode_lo (FILE *print_out, uint32_t othermode_lo)
-{
+print_othermode_lo(FILE *print_out, uint32_t othermode_lo) {
     static const struct F3DZEX_const rm_presets[] =
-    {
-        F3DZEX_CONST(G_RM_OPA_SURF),
-        F3DZEX_CONST(G_RM_OPA_SURF2),
-        F3DZEX_CONST(G_RM_AA_OPA_SURF),
-        F3DZEX_CONST(G_RM_AA_OPA_SURF2),
-        F3DZEX_CONST(G_RM_RA_OPA_SURF),
-        F3DZEX_CONST(G_RM_RA_OPA_SURF2),
-        F3DZEX_CONST(G_RM_ZB_OPA_SURF),
-        F3DZEX_CONST(G_RM_ZB_OPA_SURF2),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_SURF),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_SURF2),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_SURF),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_SURF2),
-        F3DZEX_CONST(G_RM_XLU_SURF),
-        F3DZEX_CONST(G_RM_XLU_SURF2),
-        F3DZEX_CONST(G_RM_AA_XLU_SURF),
-        F3DZEX_CONST(G_RM_AA_XLU_SURF2),
-        F3DZEX_CONST(G_RM_ZB_XLU_SURF),
-        F3DZEX_CONST(G_RM_ZB_XLU_SURF2),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_SURF),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_SURF2),
-        F3DZEX_CONST(G_RM_ZB_OPA_DECAL),
-        F3DZEX_CONST(G_RM_ZB_OPA_DECAL2),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_DECAL),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_DECAL2),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_DECAL),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_DECAL2),
-        F3DZEX_CONST(G_RM_ZB_XLU_DECAL),
-        F3DZEX_CONST(G_RM_ZB_XLU_DECAL2),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_DECAL),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_DECAL2),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_INTER),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_INTER2),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_INTER),
-        F3DZEX_CONST(G_RM_RA_ZB_OPA_INTER2),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_INTER),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_INTER2),
-        F3DZEX_CONST(G_RM_AA_XLU_LINE),
-        F3DZEX_CONST(G_RM_AA_XLU_LINE2),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_LINE),
-        F3DZEX_CONST(G_RM_AA_ZB_XLU_LINE2),
-        F3DZEX_CONST(G_RM_AA_DEC_LINE),
-        F3DZEX_CONST(G_RM_AA_DEC_LINE2),
-        F3DZEX_CONST(G_RM_AA_ZB_DEC_LINE),
-        F3DZEX_CONST(G_RM_AA_ZB_DEC_LINE2),
-        F3DZEX_CONST(G_RM_TEX_EDGE),
-        F3DZEX_CONST(G_RM_TEX_EDGE2),
-        F3DZEX_CONST(G_RM_AA_TEX_EDGE),
-        F3DZEX_CONST(G_RM_AA_TEX_EDGE2),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_EDGE),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_EDGE2),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_INTER),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_INTER2),
-        F3DZEX_CONST(G_RM_AA_SUB_SURF),
-        F3DZEX_CONST(G_RM_AA_SUB_SURF2),
-        F3DZEX_CONST(G_RM_AA_ZB_SUB_SURF),
-        F3DZEX_CONST(G_RM_AA_ZB_SUB_SURF2),
-        F3DZEX_CONST(G_RM_PCL_SURF),
-        F3DZEX_CONST(G_RM_PCL_SURF2),
-        F3DZEX_CONST(G_RM_AA_PCL_SURF),
-        F3DZEX_CONST(G_RM_AA_PCL_SURF2),
-        F3DZEX_CONST(G_RM_ZB_PCL_SURF),
-        F3DZEX_CONST(G_RM_ZB_PCL_SURF2),
-        F3DZEX_CONST(G_RM_AA_ZB_PCL_SURF),
-        F3DZEX_CONST(G_RM_AA_ZB_PCL_SURF2),
-        F3DZEX_CONST(G_RM_AA_OPA_TERR),
-        F3DZEX_CONST(G_RM_AA_OPA_TERR2),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_TERR),
-        F3DZEX_CONST(G_RM_AA_ZB_OPA_TERR2),
-        F3DZEX_CONST(G_RM_AA_TEX_TERR),
-        F3DZEX_CONST(G_RM_AA_TEX_TERR2),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_TERR),
-        F3DZEX_CONST(G_RM_AA_ZB_TEX_TERR2),
-        F3DZEX_CONST(G_RM_AA_SUB_TERR),
-        F3DZEX_CONST(G_RM_AA_SUB_TERR2),
-        F3DZEX_CONST(G_RM_AA_ZB_SUB_TERR),
-        F3DZEX_CONST(G_RM_AA_ZB_SUB_TERR2),
-        F3DZEX_CONST(G_RM_CLD_SURF),
-        F3DZEX_CONST(G_RM_CLD_SURF2),
-        F3DZEX_CONST(G_RM_ZB_CLD_SURF),
-        F3DZEX_CONST(G_RM_ZB_CLD_SURF2),
-        F3DZEX_CONST(G_RM_ZB_OVL_SURF),
-        F3DZEX_CONST(G_RM_ZB_OVL_SURF2),
-        F3DZEX_CONST(G_RM_ADD),
-        F3DZEX_CONST(G_RM_ADD2),
-        F3DZEX_CONST(G_RM_VISCVG),
-        F3DZEX_CONST(G_RM_VISCVG2),
-        F3DZEX_CONST(G_RM_OPA_CI),
-        F3DZEX_CONST(G_RM_OPA_CI2),
-        F3DZEX_CONST(G_RM_RA_SPRITE),
-        F3DZEX_CONST(G_RM_RA_SPRITE2),
-    };
+        {
+            F3DZEX_CONST(G_RM_OPA_SURF),
+            F3DZEX_CONST(G_RM_OPA_SURF2),
+            F3DZEX_CONST(G_RM_AA_OPA_SURF),
+            F3DZEX_CONST(G_RM_AA_OPA_SURF2),
+            F3DZEX_CONST(G_RM_RA_OPA_SURF),
+            F3DZEX_CONST(G_RM_RA_OPA_SURF2),
+            F3DZEX_CONST(G_RM_ZB_OPA_SURF),
+            F3DZEX_CONST(G_RM_ZB_OPA_SURF2),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_SURF),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_SURF2),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_SURF),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_SURF2),
+            F3DZEX_CONST(G_RM_XLU_SURF),
+            F3DZEX_CONST(G_RM_XLU_SURF2),
+            F3DZEX_CONST(G_RM_AA_XLU_SURF),
+            F3DZEX_CONST(G_RM_AA_XLU_SURF2),
+            F3DZEX_CONST(G_RM_ZB_XLU_SURF),
+            F3DZEX_CONST(G_RM_ZB_XLU_SURF2),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_SURF),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_SURF2),
+            F3DZEX_CONST(G_RM_ZB_OPA_DECAL),
+            F3DZEX_CONST(G_RM_ZB_OPA_DECAL2),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_DECAL),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_DECAL2),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_DECAL),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_DECAL2),
+            F3DZEX_CONST(G_RM_ZB_XLU_DECAL),
+            F3DZEX_CONST(G_RM_ZB_XLU_DECAL2),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_DECAL),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_DECAL2),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_INTER),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_INTER2),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_INTER),
+            F3DZEX_CONST(G_RM_RA_ZB_OPA_INTER2),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_INTER),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_INTER2),
+            F3DZEX_CONST(G_RM_AA_XLU_LINE),
+            F3DZEX_CONST(G_RM_AA_XLU_LINE2),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_LINE),
+            F3DZEX_CONST(G_RM_AA_ZB_XLU_LINE2),
+            F3DZEX_CONST(G_RM_AA_DEC_LINE),
+            F3DZEX_CONST(G_RM_AA_DEC_LINE2),
+            F3DZEX_CONST(G_RM_AA_ZB_DEC_LINE),
+            F3DZEX_CONST(G_RM_AA_ZB_DEC_LINE2),
+            F3DZEX_CONST(G_RM_TEX_EDGE),
+            F3DZEX_CONST(G_RM_TEX_EDGE2),
+            F3DZEX_CONST(G_RM_AA_TEX_EDGE),
+            F3DZEX_CONST(G_RM_AA_TEX_EDGE2),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_EDGE),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_EDGE2),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_INTER),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_INTER2),
+            F3DZEX_CONST(G_RM_AA_SUB_SURF),
+            F3DZEX_CONST(G_RM_AA_SUB_SURF2),
+            F3DZEX_CONST(G_RM_AA_ZB_SUB_SURF),
+            F3DZEX_CONST(G_RM_AA_ZB_SUB_SURF2),
+            F3DZEX_CONST(G_RM_PCL_SURF),
+            F3DZEX_CONST(G_RM_PCL_SURF2),
+            F3DZEX_CONST(G_RM_AA_PCL_SURF),
+            F3DZEX_CONST(G_RM_AA_PCL_SURF2),
+            F3DZEX_CONST(G_RM_ZB_PCL_SURF),
+            F3DZEX_CONST(G_RM_ZB_PCL_SURF2),
+            F3DZEX_CONST(G_RM_AA_ZB_PCL_SURF),
+            F3DZEX_CONST(G_RM_AA_ZB_PCL_SURF2),
+            F3DZEX_CONST(G_RM_AA_OPA_TERR),
+            F3DZEX_CONST(G_RM_AA_OPA_TERR2),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_TERR),
+            F3DZEX_CONST(G_RM_AA_ZB_OPA_TERR2),
+            F3DZEX_CONST(G_RM_AA_TEX_TERR),
+            F3DZEX_CONST(G_RM_AA_TEX_TERR2),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_TERR),
+            F3DZEX_CONST(G_RM_AA_ZB_TEX_TERR2),
+            F3DZEX_CONST(G_RM_AA_SUB_TERR),
+            F3DZEX_CONST(G_RM_AA_SUB_TERR2),
+            F3DZEX_CONST(G_RM_AA_ZB_SUB_TERR),
+            F3DZEX_CONST(G_RM_AA_ZB_SUB_TERR2),
+            F3DZEX_CONST(G_RM_CLD_SURF),
+            F3DZEX_CONST(G_RM_CLD_SURF2),
+            F3DZEX_CONST(G_RM_ZB_CLD_SURF),
+            F3DZEX_CONST(G_RM_ZB_CLD_SURF2),
+            F3DZEX_CONST(G_RM_ZB_OVL_SURF),
+            F3DZEX_CONST(G_RM_ZB_OVL_SURF2),
+            F3DZEX_CONST(G_RM_ADD),
+            F3DZEX_CONST(G_RM_ADD2),
+            F3DZEX_CONST(G_RM_VISCVG),
+            F3DZEX_CONST(G_RM_VISCVG2),
+            F3DZEX_CONST(G_RM_OPA_CI),
+            F3DZEX_CONST(G_RM_OPA_CI2),
+            F3DZEX_CONST(G_RM_RA_SPRITE),
+            F3DZEX_CONST(G_RM_RA_SPRITE2),
+        };
     static const struct F3DZEX_const bl1_presets[] =
-    {
-        F3DZEX_CONST(G_RM_FOG_SHADE_A),
-        F3DZEX_CONST(G_RM_FOG_PRIM_A),
-        F3DZEX_CONST(G_RM_PASS),
-        F3DZEX_CONST(G_RM_NOOP),
-    };
+        {
+            F3DZEX_CONST(G_RM_FOG_SHADE_A),
+            F3DZEX_CONST(G_RM_FOG_PRIM_A),
+            F3DZEX_CONST(G_RM_PASS),
+            F3DZEX_CONST(G_RM_NOOP),
+        };
     static const struct F3DZEX_const bl2_presets[] =
-    {
-        F3DZEX_CONST(G_RM_NOOP2),
-    };
-#define MDMASK_RM_C1	((uint32_t)0xCCCC0000)
-#define MDMASK_RM_C2	((uint32_t)0x33330000)
-#define MDMASK_RM_LO	((uint32_t)0x0000FFF8)
-#define RM_MASK         (MDMASK_RM_C1 | MDMASK_RM_C2 | MDMASK_RM_LO)
+        {
+            F3DZEX_CONST(G_RM_NOOP2),
+        };
+#define MDMASK_RM_C1 ((uint32_t)0xCCCC0000)
+#define MDMASK_RM_C2 ((uint32_t)0x33330000)
+#define MDMASK_RM_LO ((uint32_t)0x0000FFF8)
+#define RM_MASK      (MDMASK_RM_C1 | MDMASK_RM_C2 | MDMASK_RM_LO)
 
     const struct F3DZEX_const *pre_c1 = NULL;
     const struct F3DZEX_const *pre_c2 = NULL;
-    int n = 0;
+    int n                             = 0;
 
-    for (size_t i = 0; i < ARRAY_COUNT(rm_presets); i++)
-    {
+    for (size_t i = 0; i < ARRAY_COUNT(rm_presets); i++) {
         const struct F3DZEX_const *pre = &rm_presets[i];
 
         uint32_t rm_c1 = othermode_lo & (MDMASK_RM_C1 | MDMASK_RM_LO | (pre->value & ~RM_MASK));
@@ -970,27 +1001,22 @@ print_othermode_lo (FILE *print_out, uint32_t othermode_lo)
             pre_c2 = pre;
     }
 
-    if (!pre_c1 || !pre_c2 || pre_c1 + 1 != pre_c2)
-    {
-        for (size_t i = 0; i < ARRAY_COUNT(bl1_presets); i++)
-        {
+    if (!pre_c1 || !pre_c2 || pre_c1 + 1 != pre_c2) {
+        for (size_t i = 0; i < ARRAY_COUNT(bl1_presets); i++) {
             const struct F3DZEX_const *pre = &bl1_presets[i];
 
             uint32_t rm_c1 = othermode_lo & (MDMASK_RM_C1 | (pre->value & ~RM_MASK));
-            if (rm_c1 == pre->value)
-            {
+            if (rm_c1 == pre->value) {
                 pre_c1 = pre;
                 break;
             }
         }
 
-        for (size_t i = 0; i < ARRAY_COUNT(bl2_presets); i++)
-        {
+        for (size_t i = 0; i < ARRAY_COUNT(bl2_presets); i++) {
             const struct F3DZEX_const *pre = &bl2_presets[i];
 
             uint32_t rm_c2 = othermode_lo & (MDMASK_RM_C2 | (pre->value & ~RM_MASK));
-            if (rm_c2 == pre->value)
-            {
+            if (rm_c2 == pre->value) {
                 pre_c2 = pre;
                 break;
             }
@@ -1005,21 +1031,23 @@ print_othermode_lo (FILE *print_out, uint32_t othermode_lo)
     if (pre_c2)
         pre_rm |= pre_c2->value;
 
-#define CASE_PRINT(name) \
-    case name : fprintf(print_out, #name); break
-#define DEFAULT_PRINT(name) \
-    default: fprintf(print_out, "0x%08X", othermode_lo & MDMASK(name)); break
+#define CASE_PRINT(name)           \
+    case name:                     \
+        fprintf(print_out, #name); \
+        break
+#define DEFAULT_PRINT(name)                                       \
+    default:                                                      \
+        fprintf(print_out, "0x%08X", othermode_lo &MDMASK(name)); \
+        break
 
-    switch (othermode_lo & MDMASK(ALPHACOMPARE))
-    {
+    switch (othermode_lo & MDMASK(ALPHACOMPARE)) {
         CASE_PRINT(G_AC_NONE);
         CASE_PRINT(G_AC_THRESHOLD);
         CASE_PRINT(G_AC_DITHER);
         DEFAULT_PRINT(ALPHACOMPARE);
     }
     fprintf(print_out, " | ");
-    switch (othermode_lo & MDMASK(ZSRCSEL))
-    {
+    switch (othermode_lo & MDMASK(ZSRCSEL)) {
         CASE_PRINT(G_ZS_PIXEL);
         CASE_PRINT(G_ZS_PRIM);
         DEFAULT_PRINT(ZSRCSEL);
@@ -1029,8 +1057,7 @@ print_othermode_lo (FILE *print_out, uint32_t othermode_lo)
 
     uint32_t rm = othermode_lo & (RM_MASK | pre_rm);
 
-    if ((othermode_lo & ~pre_rm) & MDMASK_RM_LO)
-    {
+    if ((othermode_lo & ~pre_rm) & MDMASK_RM_LO) {
         fprintf(print_out, " | ");
         print_rm_mode(print_out, rm);
     }
@@ -1048,15 +1075,12 @@ print_othermode_lo (FILE *print_out, uint32_t othermode_lo)
         print_rm_cbl(print_out, rm, 2);
 
     uint32_t unk_mask = ~(RM_MASK | MDMASK(ALPHACOMPARE) | MDMASK(ZSRCSEL));
-    if (othermode_lo & unk_mask)
-    {
+    if (othermode_lo & unk_mask) {
         fprintf(print_out, " | 0x%08X", othermode_lo & unk_mask);
     }
 }
 
-void
-print_othermode (FILE *print_out, uint32_t othermode_hi, uint32_t othermode_lo)
-{
+void print_othermode(FILE *print_out, uint32_t othermode_hi, uint32_t othermode_lo) {
     print_othermode_hi(print_out, othermode_hi);
     fprintf(print_out, ", ");
     print_othermode_lo(print_out, othermode_lo);
@@ -1066,130 +1090,64 @@ print_othermode (FILE *print_out, uint32_t othermode_hi, uint32_t othermode_lo)
     printf(VT_RGBCOL_S("%d;%d;%d", "%d;%d;%d") "\u2584\u2584", r, g, b, r, g, b)
 
 #define CVT_PX(c, sft, mask) \
-    ((((c) >> (sft)) & (mask)) * (255/(mask)))
+    ((((c) >> (sft)) & (mask)) * (255 / (mask)))
 
-int
-draw_last_timg (gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, int width,
-                uint32_t tlut, int tlut_type, int tlut_count)
-{
+int draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, int width,
+                   uint32_t tlut, int tlut_type, int tlut_count) {
     int fmt_siz = FMT_SIZ(fmt, siz);
 
     state->rdram->seek(timg);
 
-    for (int i = 0; i < height; i++)
-    {
-        for (int j = 0; j < width; j++)
-        {
+    for (int i = 0; i < height; i++) {
+        for (int j = 0; j < width; j++) {
             switch (fmt_siz) // TODO implement transparency in some way for all of these
             {
-                case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_4b):
-                    {
-                        uint8_t i4_px_x2;
+                case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_4b): {
+                    uint8_t i4_px_x2;
 
-                        if (state->rdram->read(&i4_px_x2, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&i4_px_x2, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
 
-                        PRINT_PX(CVT_PX(i4_px_x2, 4, 15), CVT_PX(i4_px_x2, 4, 15), CVT_PX(i4_px_x2, 4, 15));
-                        j++; // TODO what happens if these 4-bit textures have an odd width?
-                        PRINT_PX(CVT_PX(i4_px_x2, 0, 15), CVT_PX(i4_px_x2, 0, 15), CVT_PX(i4_px_x2, 0, 15));
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_4b):
-                    {
-                        uint8_t ia4_px_x2;
+                    PRINT_PX(CVT_PX(i4_px_x2, 4, 15), CVT_PX(i4_px_x2, 4, 15), CVT_PX(i4_px_x2, 4, 15));
+                    j++; // TODO what happens if these 4-bit textures have an odd width?
+                    PRINT_PX(CVT_PX(i4_px_x2, 0, 15), CVT_PX(i4_px_x2, 0, 15), CVT_PX(i4_px_x2, 0, 15));
+                } break;
+                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_4b): {
+                    uint8_t ia4_px_x2;
 
-                        if (state->rdram->read(&ia4_px_x2, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&ia4_px_x2, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
 
-                        PRINT_PX(CVT_PX(ia4_px_x2, 5, 7), CVT_PX(ia4_px_x2, 5, 7), CVT_PX(ia4_px_x2, 5, 7));
-                        j++;
-                        PRINT_PX(CVT_PX(ia4_px_x2, 1, 7), CVT_PX(ia4_px_x2, 1, 7), CVT_PX(ia4_px_x2, 1, 7));
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_4b):
-                    {
-                        // TODO previewing of CI4/CI8 textures is unreliable as the TLUT may be loaded after the index
-                        // data
-                        if (tlut == 0 || tlut_type == G_TT_NONE)
-                            goto no_preview;
+                    PRINT_PX(CVT_PX(ia4_px_x2, 5, 7), CVT_PX(ia4_px_x2, 5, 7), CVT_PX(ia4_px_x2, 5, 7));
+                    j++;
+                    PRINT_PX(CVT_PX(ia4_px_x2, 1, 7), CVT_PX(ia4_px_x2, 1, 7), CVT_PX(ia4_px_x2, 1, 7));
+                } break;
+                case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_4b): {
+                    // TODO previewing of CI4/CI8 textures is unreliable as the TLUT may be loaded after the index
+                    // data
+                    if (tlut == 0 || tlut_type == G_TT_NONE)
+                        goto no_preview;
 
-                        uint8_t ci8_i_x2;
+                    uint8_t ci8_i_x2;
 
-                        if (state->rdram->read(&ci8_i_x2, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&ci8_i_x2, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
 
-                        uint16_t tlut_pxs[2];
+                    uint16_t tlut_pxs[2];
 
-                        uint32_t save_pos = state->rdram->pos();
-                        state->rdram->seek(tlut + sizeof(uint16_t) * (ci8_i_x2 >> 4));
-                        if (state->rdram->read(&tlut_pxs[0], sizeof(uint16_t), 1) != 1)
-                            goto read_err;
-                        state->rdram->seek(tlut + sizeof(uint16_t) * (ci8_i_x2 & 0xF));
-                        if (state->rdram->read(&tlut_pxs[1], sizeof(uint16_t), 1) != 1)
-                            goto read_err;
-                        state->rdram->seek(save_pos);
+                    uint32_t save_pos = state->rdram->pos();
+                    state->rdram->seek(tlut + sizeof(uint16_t) * (ci8_i_x2 >> 4));
+                    if (state->rdram->read(&tlut_pxs[0], sizeof(uint16_t), 1) != 1)
+                        goto read_err;
+                    state->rdram->seek(tlut + sizeof(uint16_t) * (ci8_i_x2 & 0xF));
+                    if (state->rdram->read(&tlut_pxs[1], sizeof(uint16_t), 1) != 1)
+                        goto read_err;
+                    state->rdram->seek(save_pos);
 
-                        for (int k = 0; k < 2; k++)
-                        {
-                            uint16_t tlut_px = BSWAP16(tlut_pxs[k]);
+                    for (int k = 0; k < 2; k++) {
+                        uint16_t tlut_px = BSWAP16(tlut_pxs[k]);
 
-                            switch (tlut_type)
-                            {
-                                case G_TT_RGBA16:
-                                    PRINT_PX(CVT_PX(tlut_px, 11, 31), CVT_PX(tlut_px, 6, 31), CVT_PX(tlut_px, 1, 31));
-                                    break;
-                                case G_TT_IA16:
-                                    PRINT_PX(CVT_PX(tlut_px, 8, 255), CVT_PX(tlut_px, 8, 255), CVT_PX(tlut_px, 8, 255));
-                                    break;
-                            }
-                        }
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_8b):
-                    {
-                        uint8_t i8_px;
-
-                        if (state->rdram->read(&i8_px, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
-
-                        PRINT_PX(CVT_PX(i8_px, 0, 255), CVT_PX(i8_px, 0, 255), CVT_PX(i8_px, 0, 255));
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_8b):
-                    {
-                        uint8_t ia8_px;
-
-                        if (state->rdram->read(&ia8_px, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
-
-                        PRINT_PX(CVT_PX(ia8_px, 4, 15), CVT_PX(ia8_px, 4, 15), CVT_PX(ia8_px, 4, 15));
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_8b):
-                    {
-                        if (tlut == 0 || tlut_type == G_TT_NONE)
-                            goto no_preview;
-
-                        uint8_t ci8_i;
-
-                        if (state->rdram->read(&ci8_i, sizeof(uint8_t), 1) != 1)
-                            goto read_err;
-
-                        // if (ci8_i > tlut_count)
-                        //     goto read_err;
-
-                        uint16_t tlut_px;
-
-                        uint32_t save_pos = state->rdram->pos();
-                        state->rdram->seek(tlut + sizeof(uint16_t) * ci8_i);
-                        if (state->rdram->read(&tlut_px, sizeof(uint16_t), 1) != 1)
-                            goto read_err;
-                        state->rdram->seek(save_pos);
-
-                        tlut_px = BSWAP16(tlut_px);
-
-                        switch (tlut_type)
-                        {
+                        switch (tlut_type) {
                             case G_TT_RGBA16:
                                 PRINT_PX(CVT_PX(tlut_px, 11, 31), CVT_PX(tlut_px, 6, 31), CVT_PX(tlut_px, 1, 31));
                                 break;
@@ -1198,45 +1156,86 @@ draw_last_timg (gfx_state_t *state, uint32_t timg, int fmt, int siz, int height,
                                 break;
                         }
                     }
-                    break;
-                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_16b):
-                    {
-                        uint16_t ia16_px;
+                } break;
+                case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_8b): {
+                    uint8_t i8_px;
 
-                        if (state->rdram->read(&ia16_px, sizeof(uint16_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&i8_px, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
 
-                        ia16_px = BSWAP16(ia16_px);
+                    PRINT_PX(CVT_PX(i8_px, 0, 255), CVT_PX(i8_px, 0, 255), CVT_PX(i8_px, 0, 255));
+                } break;
+                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_8b): {
+                    uint8_t ia8_px;
 
-                        // TODO most of these require the alpha channel to be visible to properly see what these look
-                        // like
-                        PRINT_PX(CVT_PX(ia16_px, 8, 255), CVT_PX(ia16_px, 8, 255), CVT_PX(ia16_px, 8, 255));
+                    if (state->rdram->read(&ia8_px, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
+
+                    PRINT_PX(CVT_PX(ia8_px, 4, 15), CVT_PX(ia8_px, 4, 15), CVT_PX(ia8_px, 4, 15));
+                } break;
+                case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_8b): {
+                    if (tlut == 0 || tlut_type == G_TT_NONE)
+                        goto no_preview;
+
+                    uint8_t ci8_i;
+
+                    if (state->rdram->read(&ci8_i, sizeof(uint8_t), 1) != 1)
+                        goto read_err;
+
+                    // if (ci8_i > tlut_count)
+                    //     goto read_err;
+
+                    uint16_t tlut_px;
+
+                    uint32_t save_pos = state->rdram->pos();
+                    state->rdram->seek(tlut + sizeof(uint16_t) * ci8_i);
+                    if (state->rdram->read(&tlut_px, sizeof(uint16_t), 1) != 1)
+                        goto read_err;
+                    state->rdram->seek(save_pos);
+
+                    tlut_px = BSWAP16(tlut_px);
+
+                    switch (tlut_type) {
+                        case G_TT_RGBA16:
+                            PRINT_PX(CVT_PX(tlut_px, 11, 31), CVT_PX(tlut_px, 6, 31), CVT_PX(tlut_px, 1, 31));
+                            break;
+                        case G_TT_IA16:
+                            PRINT_PX(CVT_PX(tlut_px, 8, 255), CVT_PX(tlut_px, 8, 255), CVT_PX(tlut_px, 8, 255));
+                            break;
                     }
-                    break;
-                case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b):
-                    {
-                        uint16_t rgba16_px;
+                } break;
+                case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_16b): {
+                    uint16_t ia16_px;
 
-                        if (state->rdram->read(&rgba16_px, sizeof(uint16_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&ia16_px, sizeof(uint16_t), 1) != 1)
+                        goto read_err;
 
-                        rgba16_px = BSWAP16(rgba16_px);
+                    ia16_px = BSWAP16(ia16_px);
 
-                        PRINT_PX(CVT_PX(rgba16_px, 11, 31), CVT_PX(rgba16_px, 6, 31), CVT_PX(rgba16_px, 1, 31));
-                    }
-                    break;
-                case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_32b):
-                    {
-                        uint32_t rgba32_px;
+                    // TODO most of these require the alpha channel to be visible to properly see what these look
+                    // like
+                    PRINT_PX(CVT_PX(ia16_px, 8, 255), CVT_PX(ia16_px, 8, 255), CVT_PX(ia16_px, 8, 255));
+                } break;
+                case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b): {
+                    uint16_t rgba16_px;
 
-                        if (state->rdram->read(&rgba32_px, sizeof(uint32_t), 1) != 1)
-                            goto read_err;
+                    if (state->rdram->read(&rgba16_px, sizeof(uint16_t), 1) != 1)
+                        goto read_err;
 
-                        rgba32_px = BSWAP32(rgba32_px);
+                    rgba16_px = BSWAP16(rgba16_px);
 
-                        PRINT_PX(CVT_PX(rgba32_px, 24, 255), CVT_PX(rgba32_px, 16, 255), CVT_PX(rgba32_px, 8, 255));
-                    }
-                    break;
+                    PRINT_PX(CVT_PX(rgba16_px, 11, 31), CVT_PX(rgba16_px, 6, 31), CVT_PX(rgba16_px, 1, 31));
+                } break;
+                case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_32b): {
+                    uint32_t rgba32_px;
+
+                    if (state->rdram->read(&rgba32_px, sizeof(uint32_t), 1) != 1)
+                        goto read_err;
+
+                    rgba32_px = BSWAP32(rgba32_px);
+
+                    PRINT_PX(CVT_PX(rgba32_px, 24, 255), CVT_PX(rgba32_px, 16, 255), CVT_PX(rgba32_px, 8, 255));
+                } break;
                 // TODO YUV? but who even uses YUV (it would also be more useful to show different decoding stages..)
                 default:
                     goto bad_fmt_siz_err;
@@ -1264,24 +1263,21 @@ bad_fmt_siz_err:
  */
 
 static uint32_t
-dl_stack_peek (gfx_state_t *state)
-{
+dl_stack_peek(gfx_state_t *state) {
     if (state->dl_stack_top == -1)
         return 0; // peek failed, stack empty
     return state->dl_stack[state->dl_stack_top];
 }
 
 static uint32_t
-dl_stack_pop (gfx_state_t *state)
-{
+dl_stack_pop(gfx_state_t *state) {
     if (state->dl_stack_top == -1)
         return 0; // pop failed, stack empty
     return state->dl_stack[state->dl_stack_top--];
 }
 
 static int
-dl_stack_push (gfx_state_t *state, uint32_t dl)
-{
+dl_stack_push(gfx_state_t *state, uint32_t dl) {
     if (state->dl_stack_top != ARRAY_COUNT(state->dl_stack))
         state->dl_stack[++state->dl_stack_top] = dl;
     else
@@ -1293,11 +1289,8 @@ dl_stack_push (gfx_state_t *state, uint32_t dl)
  *  Address Conversion and Checking
  */
 
-void
-print_segments (FILE *print_out, uint32_t *segment_table)
-{
-    for (int i = 0; i < 16; i++)
-    {
+void print_segments(FILE *print_out, uint32_t *segment_table) {
+    for (int i = 0; i < 16; i++) {
         fprintf(print_out, "%02X : %08X", i, segment_table[i]);
         if ((i + 1) % 4 == 0)
             fprintf(print_out, "\n");
@@ -1307,15 +1300,13 @@ print_segments (FILE *print_out, uint32_t *segment_table)
 }
 
 static bool
-addr_in_rdram (gfx_state_t *state, uint32_t addr)
-{
+addr_in_rdram(gfx_state_t *state, uint32_t addr) {
     return state->rdram->addr_valid(addr & ~KSEG_MASK);
 }
 
 static uint32_t
-segmented_to_physical (gfx_state_t *state, uint32_t addr)
-{
-    int num = (addr << 4) >> 28;
+segmented_to_physical(gfx_state_t *state, uint32_t addr) {
+    int num      = (addr << 4) >> 28;
     uint8_t num8 = addr >> 24;
 
     ARG_CHECK(state, state->segment_set_bits & (1 << num), GW_UNSET_SEGMENT);
@@ -1328,8 +1319,7 @@ segmented_to_physical (gfx_state_t *state, uint32_t addr)
 }
 
 static uint32_t
-segmented_to_kseg0 (gfx_state_t *state, uint32_t addr)
-{
+segmented_to_kseg0(gfx_state_t *state, uint32_t addr) {
     return 0x80000000 | segmented_to_physical(state, addr);
 }
 
@@ -1338,26 +1328,21 @@ segmented_to_kseg0 (gfx_state_t *state, uint32_t addr)
  */
 
 static inline void
-f_to_qs1616 (int16_t *int_out, uint16_t *frac_out, float f)
-{
+f_to_qs1616(int16_t *int_out, uint16_t *frac_out, float f) {
     qs1616_t q = qs1616(f);
 
-    *int_out = (int16_t)(q >> 16);
+    *int_out  = (int16_t)(q >> 16);
     *frac_out = (uint16_t)(q & 0xFFFF);
 }
 
 static inline float
-qs1616_to_f (int16_t int_part, uint16_t frac_part)
-{
+qs1616_to_f(int16_t int_part, uint16_t frac_part) {
     return ((int_part << 16) | (frac_part)) / (float)0x10000;
 }
 
-void
-mtxf_to_mtx (Mtx *mtx, MtxF *mf, bool swap)
-{
+void mtxf_to_mtx(Mtx *mtx, MtxF *mf, bool swap) {
     for (int i = 0; i < 4; i++)
-        for (int j = 0; j < 4; j++)
-        {
+        for (int j = 0; j < 4; j++) {
             int16_t ipart;
             uint16_t fpart;
 
@@ -1368,12 +1353,9 @@ mtxf_to_mtx (Mtx *mtx, MtxF *mf, bool swap)
         }
 }
 
-void
-mtx_to_mtxf (MtxF *mf, Mtx *mtx, bool swap)
-{
+void mtx_to_mtxf(MtxF *mf, Mtx *mtx, bool swap) {
     for (int i = 0; i < 4; i++)
-        for (int j = 0; j < 4; j++)
-        {
+        for (int j = 0; j < 4; j++) {
             mtx->i[i + 4 * j] = MAYBE_BSWAP16(mtx->i[i + 4 * j], swap);
             mtx->f[i + 4 * j] = MAYBE_BSWAP16(mtx->f[i + 4 * j], swap);
 
@@ -1381,26 +1363,17 @@ mtx_to_mtxf (MtxF *mf, Mtx *mtx, bool swap)
         }
 }
 
-void
-mtxf_mtxf_mul (MtxF *dst, MtxF *m0, MtxF *m1)
-{
+void mtxf_mtxf_mul(MtxF *dst, MtxF *m0, MtxF *m1) {
     int i;
-    for (i = 0; i < 4; i++)
-    {
-        dst->mf[0][i] = m0->mf[0][i] * m1->mf[0][0] + m0->mf[1][i] * m1->mf[0][1]
-                      + m0->mf[2][i] * m1->mf[0][2] + m0->mf[3][i] * m1->mf[0][3];
-        dst->mf[1][i] = m0->mf[0][i] * m1->mf[1][0] + m0->mf[1][i] * m1->mf[1][1]
-                      + m0->mf[2][i] * m1->mf[1][2] + m0->mf[3][i] * m1->mf[1][3];
-        dst->mf[2][i] = m0->mf[0][i] * m1->mf[2][0] + m0->mf[1][i] * m1->mf[2][1]
-                      + m0->mf[2][i] * m1->mf[2][2] + m0->mf[3][i] * m1->mf[2][3];
-        dst->mf[3][i] = m0->mf[3][i] * m1->mf[3][3] + m0->mf[2][i] * m1->mf[3][2]
-                      + m0->mf[1][i] * m1->mf[3][1] + m0->mf[0][i] * m1->mf[3][0];
+    for (i = 0; i < 4; i++) {
+        dst->mf[0][i] = m0->mf[0][i] * m1->mf[0][0] + m0->mf[1][i] * m1->mf[0][1] + m0->mf[2][i] * m1->mf[0][2] + m0->mf[3][i] * m1->mf[0][3];
+        dst->mf[1][i] = m0->mf[0][i] * m1->mf[1][0] + m0->mf[1][i] * m1->mf[1][1] + m0->mf[2][i] * m1->mf[1][2] + m0->mf[3][i] * m1->mf[1][3];
+        dst->mf[2][i] = m0->mf[0][i] * m1->mf[2][0] + m0->mf[1][i] * m1->mf[2][1] + m0->mf[2][i] * m1->mf[2][2] + m0->mf[3][i] * m1->mf[2][3];
+        dst->mf[3][i] = m0->mf[3][i] * m1->mf[3][3] + m0->mf[2][i] * m1->mf[3][2] + m0->mf[1][i] * m1->mf[3][1] + m0->mf[0][i] * m1->mf[3][0];
     }
 }
 
-void
-mtxf_mtxf_mul_inplace (MtxF *m0, MtxF *m1)
-{
+void mtxf_mtxf_mul_inplace(MtxF *m0, MtxF *m1) {
     MtxF tmp;
     mtxf_mtxf_mul(&tmp, m0, m1);
     *m0 = tmp;
@@ -1412,13 +1385,12 @@ mtxf_mtxf_mul_inplace (MtxF *m0, MtxF *m1)
 
 typedef int (*chk_fn)(gfx_state_t *);
 
-#define CHECK_PIPESYNC(state) ARG_CHECK(state, !state->pipe_busy, GW_MISSING_PIPESYNC)
-#define CHECK_LOADSYNC(state) ARG_CHECK(state, !state->load_busy, GW_MISSING_LOADSYNC)
+#define CHECK_PIPESYNC(state)       ARG_CHECK(state, !state->pipe_busy, GW_MISSING_PIPESYNC)
+#define CHECK_LOADSYNC(state)       ARG_CHECK(state, !state->load_busy, GW_MISSING_LOADSYNC)
 #define CHECK_TILESYNC(state, tile) ARG_CHECK(state, !state->tile_busy[(tile)], GW_MISSING_TILESYNC)
 
 static int
-chk_Range (gfx_state_t *state, uint32_t addr, size_t len)
-{
+chk_Range(gfx_state_t *state, uint32_t addr, size_t len) {
     ARG_CHECK(state, addr_in_rdram(state, addr), GW_ADDR_NOT_IN_RDRAM);
     if (len != 0)
         ARG_CHECK(state, addr_in_rdram(state, addr + len), GW_RANGE_NOT_IN_RDRAM);
@@ -1427,10 +1399,8 @@ chk_Range (gfx_state_t *state, uint32_t addr, size_t len)
 }
 
 static bool
-chk_ValidImgFmt (int fmt)
-{
-    switch (fmt)
-    {
+chk_ValidImgFmt(int fmt) {
+    switch (fmt) {
         case G_IM_FMT_RGBA:
         case G_IM_FMT_YUV:
         case G_IM_FMT_CI:
@@ -1442,20 +1412,18 @@ chk_ValidImgFmt (int fmt)
 }
 
 static bool
-chk_ValidImgFmtSiz (int fmt, int siz)
-{
-    switch (FMT_SIZ(fmt, siz))
-    {
+chk_ValidImgFmtSiz(int fmt, int siz) {
+    switch (FMT_SIZ(fmt, siz)) {
         case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_32b):
         case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b):
         case FMT_SIZ(G_IM_FMT_YUV, G_IM_SIZ_16b):
         case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_16b):
         case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_8b):
         case FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_4b):
-        case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_16b):    // loadblock
+        case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_16b): // loadblock
         case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_8b):
         case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_4b):
-        case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_16b):     // loadblock
+        case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_16b): // loadblock
         case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_8b):
         case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_4b):
             return true;
@@ -1464,9 +1432,8 @@ chk_ValidImgFmtSiz (int fmt, int siz)
 }
 
 static int
-chk_SPBranchList (gfx_state_t *state)
-{
-    uint32_t dl = gfxd_arg_value(0)->u;
+chk_SPBranchList(gfx_state_t *state) {
+    uint32_t dl      = gfxd_arg_value(0)->u;
     uint32_t dl_phys = segmented_to_physical(state, dl);
 
     // We don't actually know the length of the display list being branched to,
@@ -1478,8 +1445,7 @@ chk_SPBranchList (gfx_state_t *state)
 }
 
 static int
-chk_SPDisplayList (gfx_state_t *state)
-{
+chk_SPDisplayList(gfx_state_t *state) {
     if (dl_stack_push(state, state->gfx_addr) == -1)
         WARNING_ERROR(state, GW_DL_STACK_OVERFLOW);
 
@@ -1487,8 +1453,7 @@ chk_SPDisplayList (gfx_state_t *state)
 }
 
 static int
-chk_DisplayList (gfx_state_t *state)
-{
+chk_DisplayList(gfx_state_t *state) {
     int flag = gfxd_arg_value(1)->u;
 
     const char *acts_as = (flag & 1) ? "SPBranchList" : "SPDisplayList";
@@ -1500,8 +1465,7 @@ chk_DisplayList (gfx_state_t *state)
 }
 
 static int
-chk_SPEndDisplayList (gfx_state_t *state)
-{
+chk_SPEndDisplayList(gfx_state_t *state) {
     if (state->dl_stack_top == -1) // dl stack empty, task is done
         state->task_done = true;
     else
@@ -1510,8 +1474,7 @@ chk_SPEndDisplayList (gfx_state_t *state)
 }
 
 static int
-chk_SPCullDisplayList (gfx_state_t *state)
-{
+chk_SPCullDisplayList(gfx_state_t *state) {
     int v0 = gfxd_arg_value(0)->i;
     int vn = gfxd_arg_value(1)->i;
 
@@ -1529,15 +1492,13 @@ chk_SPCullDisplayList (gfx_state_t *state)
     int check = CLIP_ALL;
 
     int *startClip = &state->vtx_clipcodes[v0];
-    int *endClip = &state->vtx_clipcodes[vn];
+    int *endClip   = &state->vtx_clipcodes[vn];
 
-    do
-    {
+    do {
         check &= *startClip;
         if (check == 0)
             return 0; // at least one vertex on-screen, execute next command in display list
-    }
-    while((startClip++) != endClip);
+    } while ((startClip++) != endClip);
 
     Note(gfxd_vprintf, "Display list culled");
 
@@ -1546,8 +1507,7 @@ chk_SPCullDisplayList (gfx_state_t *state)
 }
 
 static int
-chk_SPSegment (gfx_state_t *state)
-{
+chk_SPSegment(gfx_state_t *state) {
     int num      = gfxd_arg_value(0)->u;
     uint32_t seg = gfxd_arg_value(1)->u;
 
@@ -1559,24 +1519,21 @@ chk_SPSegment (gfx_state_t *state)
     return 0;
 }
 
-void
-print_mtx_params (FILE *print_out, uint32_t params)
-{
+void print_mtx_params(FILE *print_out, uint32_t params) {
     struct
     {
         uint32_t value;
         const char *set_name;
         const char *unset_name;
     } mtx_params[] =
-    {
-        F3DZEX_MTX_PARAM(G_MTX_PUSH, G_MTX_NOPUSH),
-        F3DZEX_MTX_PARAM(G_MTX_LOAD, G_MTX_MUL),
-        F3DZEX_MTX_PARAM(G_MTX_PROJECTION, G_MTX_MODELVIEW),
-    };
+        {
+            F3DZEX_MTX_PARAM(G_MTX_PUSH, G_MTX_NOPUSH),
+            F3DZEX_MTX_PARAM(G_MTX_LOAD, G_MTX_MUL),
+            F3DZEX_MTX_PARAM(G_MTX_PROJECTION, G_MTX_MODELVIEW),
+        };
     bool first = true;
 
-    for (size_t i = 0; i < ARRAY_COUNT(mtx_params); i++)
-    {
+    for (size_t i = 0; i < ARRAY_COUNT(mtx_params); i++) {
         if (!first)
             fprintf(print_out, " | ");
 
@@ -1585,8 +1542,7 @@ print_mtx_params (FILE *print_out, uint32_t params)
         params &= ~mtx_params[i].value;
         first = false;
     }
-    if (params != 0)
-    {
+    if (params != 0) {
         if (!first)
             fprintf(print_out, " | ");
         fprintf(print_out, "0x%08X", params);
@@ -1594,22 +1550,28 @@ print_mtx_params (FILE *print_out, uint32_t params)
 }
 
 static void
-print_mtx (MtxF *mf)
-{
-    gfxd_printf("        "  "/ %15.6f  %15.6f  %15.6f  %15.6f \\" "\n",
+print_mtx(MtxF *mf) {
+    gfxd_printf("        "
+                "/ %15.6f  %15.6f  %15.6f  %15.6f \\"
+                "\n",
                 mf->mf[0][0], mf->mf[0][1], mf->mf[0][2], mf->mf[0][3]);
-    gfxd_printf("        "  "| %15.6f  %15.6f  %15.6f  %15.6f |"  "\n",
+    gfxd_printf("        "
+                "| %15.6f  %15.6f  %15.6f  %15.6f |"
+                "\n",
                 mf->mf[1][0], mf->mf[1][1], mf->mf[1][2], mf->mf[1][3]);
-    gfxd_printf("        "  "| %15.6f  %15.6f  %15.6f  %15.6f |"  "\n",
+    gfxd_printf("        "
+                "| %15.6f  %15.6f  %15.6f  %15.6f |"
+                "\n",
                 mf->mf[2][0], mf->mf[2][1], mf->mf[2][2], mf->mf[2][3]);
-    gfxd_printf("        " "\\ %15.6f  %15.6f  %15.6f  %15.6f /"  "\n",
+    gfxd_printf("        "
+                "\\ %15.6f  %15.6f  %15.6f  %15.6f /"
+                "\n",
                 mf->mf[3][0], mf->mf[3][1], mf->mf[3][2], mf->mf[3][3]);
     gfxd_printf("\n");
 }
 
 static int
-chk_SPMatrix (gfx_state_t *state)
-{
+chk_SPMatrix(gfx_state_t *state) {
     uint32_t matrix = gfxd_arg_value(0)->u;
     int param       = gfxd_arg_value(1)->i;
 
@@ -1618,32 +1580,25 @@ chk_SPMatrix (gfx_state_t *state)
     chk_Range(state, matrix_phys, sizeof(Mtx));
 
     int projection = (param & G_MTX_PROJECTION) == G_MTX_PROJECTION;
-    int push = (param & G_MTX_PUSH) == G_MTX_PUSH;
-    int load = (param & G_MTX_LOAD) == G_MTX_LOAD;
+    int push       = (param & G_MTX_PUSH) == G_MTX_PUSH;
+    int load       = (param & G_MTX_LOAD) == G_MTX_LOAD;
 
     ARG_CHECK(state, !(push && projection), GW_MTX_PUSHED_TO_PROJECTION);
 
-    if (push)
-    {
+    if (push) {
         ARG_CHECK(state, state->matrix_stack_depth * sizeof(Mtx) <= state->sp_dram_stack_size, GW_MTX_STACK_OVERFLOW);
         state->matrix_stack_depth++;
     }
 
-    if (load)
-    {
+    if (load) {
         if (projection)
             state->matrix_projection_set = true;
         else
             state->matrix_modelview_set = true;
-    }
-    else
-    {
-        if (projection)
-        {
+    } else {
+        if (projection) {
             ARG_CHECK(state, state->matrix_projection_set, GW_MUL_PROJECTION_UNSET);
-        }
-        else
-        {
+        } else {
             ARG_CHECK(state, state->matrix_modelview_set, GW_MUL_MODELVIEW_UNSET);
         }
     }
@@ -1659,37 +1614,26 @@ chk_SPMatrix (gfx_state_t *state)
     if (state->options->print_matrices)
         print_mtx(&mf);
 
-    if (projection)
-    {
-        if (!load)
-        {
+    if (projection) {
+        if (!load) {
             mtxf_mtxf_mul_inplace(&state->projection_mtx, &mf);
-        }
-        else
-        {
+        } else {
             state->projection_mtx = mf;
         }
-    }
-    else
-    {
-        if (!load)
-        {
-            mtxf_mtxf_mul_inplace(&mf, (MtxF*)obstack_peek(&state->mtx_stack));
+    } else {
+        if (!load) {
+            mtxf_mtxf_mul_inplace(&mf, (MtxF *)obstack_peek(&state->mtx_stack));
         }
 
-        if (push)
-        {
+        if (push) {
             obstack_push(&state->mtx_stack, &mf);
-        }
-        else
-        {
-            *(MtxF*)obstack_peek(&state->mtx_stack) = mf;
+        } else {
+            *(MtxF *)obstack_peek(&state->mtx_stack) = mf;
         }
     }
 
-    if (state->matrix_projection_set && state->matrix_modelview_set)
-    {
-        mtxf_mtxf_mul(&state->mvp_mtx, (MtxF*)obstack_peek(&state->mtx_stack), &state->projection_mtx);
+    if (state->matrix_projection_set && state->matrix_modelview_set) {
+        mtxf_mtxf_mul(&state->mvp_mtx, (MtxF *)obstack_peek(&state->mtx_stack), &state->projection_mtx);
 
         if (state->options->print_matrices)
             print_mtx(&state->mvp_mtx);
@@ -1697,13 +1641,12 @@ chk_SPMatrix (gfx_state_t *state)
 
     return 0;
 err:
-    gfxd_printf(VT_COL(RED,WHITE) "READ ERROR" VT_RST "\n");
+    gfxd_printf(VT_COL(RED, WHITE) "READ ERROR" VT_RST "\n");
     return 0;
 }
 
 static int
-chk_scissor_cimg (gfx_state_t *state)
-{
+chk_scissor_cimg(gfx_state_t *state) {
     // TODO it would be nice if we could check new cimg-scissor combinations as well as just the first two
     if (state->cimg_scissor_valid)
         return 0;
@@ -1729,24 +1672,23 @@ chk_scissor_cimg (gfx_state_t *state)
     }
     idx = (idx + 3) >> 2; // round up fractional values
 
-    uint32_t scis_end_addr   = state->last_cimg.addr + (G_SIZ_BITS(state->last_cimg.siz) * idx) / 8;
+    uint32_t scis_end_addr = state->last_cimg.addr + (G_SIZ_BITS(state->last_cimg.siz) * idx) / 8;
 
     // printf("\n(%08X,%u) + (%u,%u),(%u,%u) -> %08X,%08X\n", state->last_cimg.addr, state->last_cimg.width,
     //        state->scissor.ulx, state->scissor.uly, state->scissor.lrx, state->scissor.lry,
     //        scis_start_addr, scis_end_addr);
 
     ARG_CHECK(state, state->rdram->addr_valid(scis_start_addr), GW_SCISSOR_START_INVALID);
-    ARG_CHECK(state, state->rdram->addr_valid(scis_end_addr-1), GW_SCISSOR_END_INVALID);
+    ARG_CHECK(state, state->rdram->addr_valid(scis_end_addr - 1), GW_SCISSOR_END_INVALID);
     return 0;
 }
 
 static int
-chk_DPSetColorImage (gfx_state_t *state)
-{
-    int fmt = gfxd_arg_value(0)->i;
-    int siz = gfxd_arg_value(1)->i;
-    int width = gfxd_arg_value(2)->i;
-    uint32_t cimg = gfxd_arg_value(3)->u;
+chk_DPSetColorImage(gfx_state_t *state) {
+    int fmt            = gfxd_arg_value(0)->i;
+    int siz            = gfxd_arg_value(1)->i;
+    int width          = gfxd_arg_value(2)->i;
+    uint32_t cimg      = gfxd_arg_value(3)->u;
     uint32_t cimg_phys = segmented_to_physical(state, cimg);
 
     CHECK_PIPESYNC(state);
@@ -1758,8 +1700,7 @@ chk_DPSetColorImage (gfx_state_t *state)
 
     ARG_CHECK(state, cimg_phys % 64 == 0, GW_BAD_CIMG_ALIGNMENT);
 
-    switch (FMT_SIZ(fmt, siz))
-    {
+    switch (FMT_SIZ(fmt, siz)) {
         case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_32b):
         case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b):
         case FMT_SIZ(G_IM_FMT_I, G_IM_SIZ_8b):
@@ -1769,21 +1710,20 @@ chk_DPSetColorImage (gfx_state_t *state)
             break;
     }
 
-    state->last_cimg.fmt = fmt;
-    state->last_cimg.siz = siz;
+    state->last_cimg.fmt   = fmt;
+    state->last_cimg.siz   = siz;
     state->last_cimg.width = width;
-    state->last_cimg.addr = cimg_phys;
-    state->cimg_set = true;
-    
+    state->last_cimg.addr  = cimg_phys;
+    state->cimg_set        = true;
+
     if (state->scissor_set)
         return chk_scissor_cimg(state);
     return 0;
 }
 
 static int
-chk_DPSetDepthImage (gfx_state_t *state)
-{
-    uint32_t zimg = gfxd_arg_value(0)->u;
+chk_DPSetDepthImage(gfx_state_t *state) {
+    uint32_t zimg      = gfxd_arg_value(0)->u;
     uint32_t zimg_phys = segmented_to_physical(state, zimg);
 
     CHECK_PIPESYNC(state);
@@ -1795,17 +1735,16 @@ chk_DPSetDepthImage (gfx_state_t *state)
     ARG_CHECK(state, zimg_phys % 64 == 0, GW_BAD_ZIMG_ALIGNMENT);
 
     state->last_zimg.addr = zimg_phys;
-    state->zimg_set = true;
+    state->zimg_set       = true;
     return 0;
 }
 
 static int
-chk_DPSetTextureImage (gfx_state_t *state)
-{
-    int fmt = gfxd_arg_value(0)->i;
-    int siz = gfxd_arg_value(1)->i;
-    int width = gfxd_arg_value(2)->i;
-    uint32_t timg = gfxd_arg_value(3)->u;
+chk_DPSetTextureImage(gfx_state_t *state) {
+    int fmt            = gfxd_arg_value(0)->i;
+    int siz            = gfxd_arg_value(1)->i;
+    int width          = gfxd_arg_value(2)->i;
+    uint32_t timg      = gfxd_arg_value(3)->u;
     uint32_t timg_phys = segmented_to_physical(state, timg);
 
     // This attribute does not need a pipe sync, it is only used by load commands.
@@ -1818,20 +1757,19 @@ chk_DPSetTextureImage (gfx_state_t *state)
 
     ARG_CHECK(state, (timg_phys % 8) == 0, GW_DANGEROUS_TEXTURE_ALIGNMENT);
 
-    state->last_timg.fmt = fmt;
-    state->last_timg.siz = siz;
+    state->last_timg.fmt   = fmt;
+    state->last_timg.siz   = siz;
     state->last_timg.width = width;
-    state->last_timg.addr = timg_phys;
+    state->last_timg.addr  = timg_phys;
     return 0;
 }
 
 typedef struct
 {
-    float x,y,z;
+    float x, y, z;
 } Vec3f;
 
-void
-mtxf_mulvec3 (Vec3f *dst, float *w, Vec3f *src, MtxF *mf) {
+void mtxf_mulvec3(Vec3f *dst, float *w, Vec3f *src, MtxF *mf) {
     dst->x = src->x * mf->mf[0][0] + src->y * mf->mf[1][0] + src->z * mf->mf[2][0] + mf->mf[3][0];
     dst->y = src->x * mf->mf[0][1] + src->y * mf->mf[1][1] + src->z * mf->mf[2][1] + mf->mf[3][1];
     dst->z = src->x * mf->mf[0][2] + src->y * mf->mf[1][2] + src->z * mf->mf[2][2] + mf->mf[3][2];
@@ -1839,14 +1777,11 @@ mtxf_mulvec3 (Vec3f *dst, float *w, Vec3f *src, MtxF *mf) {
 }
 
 static int
-print_vtx (gfx_state_t *state, uint32_t vtx_addr, int v0, int num)
-{
+print_vtx(gfx_state_t *state, uint32_t vtx_addr, int v0, int num) {
     state->rdram->seek(vtx_addr);
 
-    for (int i = 0; i < num; i++)
-    {
-        if (v0 + num >= VTX_CACHE_SIZE)
-        {
+    for (int i = 0; i < num; i++) {
+        if (v0 + num >= VTX_CACHE_SIZE) {
             // Don't process anything that's out of bounds
             break;
         }
@@ -1887,7 +1822,7 @@ print_vtx (gfx_state_t *state, uint32_t vtx_addr, int v0, int num)
 #endif
 
         state->vtx_depths[v0 + i] = (screen_pos.z / w) * 1023.0f;
-        state->vtx_w[v0 + i] = w;
+        state->vtx_w[v0 + i]      = w;
 
         state->vtx_clipcodes[v0 + i] = 0;
 
@@ -1914,13 +1849,12 @@ print_vtx (gfx_state_t *state, uint32_t vtx_addr, int v0, int num)
     }
     return 0;
 err:
-    gfxd_printf(VT_COL(RED,WHITE) "READ ERROR" VT_RST "\n");
+    gfxd_printf(VT_COL(RED, WHITE) "READ ERROR" VT_RST "\n");
     return -1;
 }
 
 static int
-chk_SPVertex (gfx_state_t *state)
-{
+chk_SPVertex(gfx_state_t *state) {
     uint32_t v = gfxd_arg_value(0)->u;
     int n      = gfxd_arg_value(1)->i;
     int v0     = gfxd_arg_value(2)->i;
@@ -1943,8 +1877,7 @@ chk_SPVertex (gfx_state_t *state)
 }
 
 static int
-chk_SPViewport (gfx_state_t *state)
-{
+chk_SPViewport(gfx_state_t *state) {
     uint32_t v      = gfxd_arg_value(0)->u;
     uint32_t v_phys = segmented_to_physical(state, v);
 
@@ -1961,24 +1894,22 @@ chk_SPViewport (gfx_state_t *state)
     state->cur_vp.vp.vtrans[2] = BSWAP16(state->cur_vp.vp.vtrans[2]);
 
     gfxd_printf(
-       "        VIEWPORT(\n"
-       "            .vscale.x = qs142(%8.2f), .vtrans.x = qs142(%8.2f)\n"
-       "            .vscale.y = qs142(%8.2f), .vtrans.y = qs142(%8.2f)\n"
-       "            .vscale.z = qs142(%8.2f), .vtrans.z = qs142(%8.2f)\n"
-       "        );\n",
+        "        VIEWPORT(\n"
+        "            .vscale.x = qs142(%8.2f), .vtrans.x = qs142(%8.2f)\n"
+        "            .vscale.y = qs142(%8.2f), .vtrans.y = qs142(%8.2f)\n"
+        "            .vscale.z = qs142(%8.2f), .vtrans.z = qs142(%8.2f)\n"
+        "        );\n",
         state->cur_vp.vp.vscale[0] / 4.0f, state->cur_vp.vp.vtrans[0] / 4.0f,
         state->cur_vp.vp.vscale[1] / 4.0f, state->cur_vp.vp.vtrans[1] / 4.0f,
-        state->cur_vp.vp.vscale[2] / 4.0f, state->cur_vp.vp.vtrans[2] / 4.0f
-    );
+        state->cur_vp.vp.vscale[2] / 4.0f, state->cur_vp.vp.vtrans[2] / 4.0f);
 
     return 0;
 err:
-    gfxd_printf(VT_COL(RED,WHITE) "READ ERROR" VT_RST "\n");
+    gfxd_printf(VT_COL(RED, WHITE) "READ ERROR" VT_RST "\n");
     return -1;
 }
 
-enum prim_type
-{
+enum prim_type {
     PRIM_TYPE_TRI,
     PRIM_TYPE_TEXRECT,
     PRIM_TYPE_FILLRECT
@@ -1994,26 +1925,23 @@ enum prim_type
     ((cc)->Aa##clk == (input) || (cc)->Ab##clk == (input) || (cc)->Ac##clk == (input) || (cc)->Ad##clk == (input))
 
 static int
-chk_render_tile (gfx_state_t *state, int tile)
-{
+chk_render_tile(gfx_state_t *state, int tile) {
     int cycle_type = OTHERMODE_VAL(state, hi, CYCLETYPE);
-    int tlut_en = OTHERMODE_VAL(state, hi, TEXTLUT) != G_TT_NONE;
+    int tlut_en    = OTHERMODE_VAL(state, hi, TEXTLUT) != G_TT_NONE;
 
     tile_descriptor_t *tile_desc = get_tile_desc(state, tile);
     ARG_CHECK(state, tile_desc != NULL, GW_TILEDESC_BAD);
 
-    if (tile_desc != NULL)
-    {
+    if (tile_desc != NULL) {
         if (tile_desc->fmt == G_IM_FMT_CI)
             ARG_CHECK(state, tlut_en, GW_CI_RENDER_TILE_NO_TLUT);
         else
             ARG_CHECK(state, !tlut_en, GW_NO_CI_RENDER_TILE_TLUT);
 
-        if (cycle_type == G_CYC_COPY)
-        {
+        if (cycle_type == G_CYC_COPY) {
             if (state->last_cimg.siz != G_IM_SIZ_8b)
                 ARG_CHECK(state, tile_desc->siz != G_IM_SIZ_4b && tile_desc->siz != G_IM_SIZ_8b,
-                            GW_COPYMODE_MISMATCH_8B);
+                          GW_COPYMODE_MISMATCH_8B);
 
             if (state->last_cimg.siz == G_IM_SIZ_16b)
                 ARG_CHECK(state, tile_desc->siz == G_IM_SIZ_16b, GW_COPYMODE_MISMATCH_16B);
@@ -2022,16 +1950,15 @@ chk_render_tile (gfx_state_t *state, int tile)
 
     // TODO if triangle is textured, are loadsync and/or tilesync needed?
     state->tile_busy[tile] = 1;
-    state->load_busy = true;
+    state->load_busy       = true;
     return 0;
 }
 
 static int
-chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
-{
+chk_render_primitive(gfx_state_t *state, enum prim_type prim_type, int tile) {
     bool uses_texel1 = false;
 
-    uint32_t rm = OTHERMODE_VAL(state, lo, RENDERMODE);
+    uint32_t rm    = OTHERMODE_VAL(state, lo, RENDERMODE);
     int cycle_type = OTHERMODE_VAL(state, hi, CYCLETYPE);
 
     ARG_CHECK(state, !((cycle_type == G_CYC_FILL && state->last_cimg.siz == G_IM_SIZ_4b)), GW_FILLMODE_4B);
@@ -2042,12 +1969,11 @@ chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
 
     bool bl_c1_set = BL_CYC_IS_SET(&state->bl, 1);
     bool bl_c2_set = BL_CYC_IS_SET(&state->bl, 2);
-    bool blend_en = (rm & (AA_EN | FORCE_BL)) != 0;
+    bool blend_en  = (rm & (AA_EN | FORCE_BL)) != 0;
 
     ARG_CHECK(state, blend_en || !(bl_c1_set || bl_c2_set), GW_BLENDER_SET_BUT_UNUSED);
 
-    if (cycle_type == G_CYC_FILL)
-    {
+    if (cycle_type == G_CYC_FILL) {
         ARG_CHECK(state, prim_type != PRIM_TYPE_TRI, GW_TRI_IN_FILLMODE);
         ARG_CHECK(state, prim_type != PRIM_TYPE_TEXRECT, GW_TEXRECT_IN_FILLMODE);
 
@@ -2055,19 +1981,16 @@ chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
             ARG_CHECK(state, state->fill_color_set, GW_FILLRECT_FILLCOLOR_UNSET);
     }
 
-    if (cycle_type != G_CYC_FILL && cycle_type != G_CYC_COPY)
-    {
+    if (cycle_type != G_CYC_FILL && cycle_type != G_CYC_COPY) {
         // Check SHADE inputs
         // Fillrect doesn't seem to care about any of this
-        if (prim_type != PRIM_TYPE_FILLRECT)
-        {
+        if (prim_type != PRIM_TYPE_FILLRECT) {
             // If G_SHADE is unset shade coefficients are not generated for RDP triangles, so shade inputs to CC and BL
             // are prohibited as they will read garbage
-            if (prim_type == PRIM_TYPE_TEXRECT || !(state->geometry_mode & G_SHADE))
-            {
+            if (prim_type == PRIM_TYPE_TEXRECT || !(state->geometry_mode & G_SHADE)) {
                 const char *errmsg = (prim_type == PRIM_TYPE_TEXRECT)
-                                   ? "rendering textured rectangle"
-                                   : "G_SHADE not set in geometry mode";
+                                         ? "rendering textured rectangle"
+                                         : "G_SHADE not set in geometry mode";
 
                 ARG_CHECK(state, !CC_C_HAS(&state->cc, G_CCMUX_SHADE, 0) && !(state->cc.c0 == G_CCMUX_SHADE_ALPHA),
                           GW_CC_SHADE_INVALID, 1, "RGB", errmsg);
@@ -2085,38 +2008,29 @@ chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
     }
 
     uint32_t zsrc = OTHERMODE_VAL(state, lo, ZSRCSEL);
-    int z_cmp = (rm & Z_CMP) != 0;
-    int z_upd = (rm & Z_UPD) != 0;
+    int z_cmp     = (rm & Z_CMP) != 0;
+    int z_upd     = (rm & Z_UPD) != 0;
 
     // Check z-buffer settings if enabled
-    if (z_cmp || z_upd)
-    {
-        if (prim_type == PRIM_TYPE_TRI)
-        {
+    if (z_cmp || z_upd) {
+        if (prim_type == PRIM_TYPE_TRI) {
             ARG_CHECK(state, zsrc == G_ZS_PRIM || (state->geometry_mode & G_ZBUFFER),
                       GW_ZS_PIXEL_SET_WITHOUT_G_ZBUFFER);
-        }
-        else
-        {
+        } else {
             ARG_CHECK(state, zsrc == G_ZS_PRIM, GW_ZSRC_INVALID);
         }
     }
 
-    switch (cycle_type)
-    {
+    switch (cycle_type) {
         case G_CYC_1CYCLE:
             // check blender configuration is the same for 1-Cycle mode
             // TODO check this
-            ARG_CHECK(state, state->bl.m1a_c1 == state->bl.m1a_c2 && state->bl.m1b_c1 == state->bl.m1b_c2 &&
-                             state->bl.m2a_c1 == state->bl.m2a_c2 && state->bl.m2b_c1 == state->bl.m2b_c2,
-                             GW_BLENDER_STAGES_DIFFER_1CYC);
+            ARG_CHECK(state, state->bl.m1a_c1 == state->bl.m1a_c2 && state->bl.m1b_c1 == state->bl.m1b_c2 && state->bl.m2a_c1 == state->bl.m2a_c2 && state->bl.m2b_c1 == state->bl.m2b_c2,
+                      GW_BLENDER_STAGES_DIFFER_1CYC);
 
             // check cc configuration is the same for 1-Cycle mode
-            ARG_CHECK(state, state->cc.a0 == state->cc.a1 && state->cc.b0 == state->cc.b1 &&
-                             state->cc.c0 == state->cc.c1 && state->cc.d0 == state->cc.d1 &&
-                             state->cc.Aa0 == state->cc.Aa1 && state->cc.Ab0 == state->cc.Ab1 &&
-                             state->cc.Ac0 == state->cc.Ac1 && state->cc.Ad0 == state->cc.Ad1,
-                             GW_CC_STAGES_DIFFER_1CYC);
+            ARG_CHECK(state, state->cc.a0 == state->cc.a1 && state->cc.b0 == state->cc.b1 && state->cc.c0 == state->cc.c1 && state->cc.d0 == state->cc.d1 && state->cc.Aa0 == state->cc.Aa1 && state->cc.Ab0 == state->cc.Ab1 && state->cc.Ac0 == state->cc.Ac1 && state->cc.Ad0 == state->cc.Ad1,
+                      GW_CC_STAGES_DIFFER_1CYC);
 
             // check cc does not use COMBINED input
             ARG_CHECK(state, !CC_C_HAS(&state->cc, G_CCMUX_COMBINED, 1), GW_CC_COMBINED_IN_C1, "RGB");
@@ -2165,11 +2079,9 @@ chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
             break;
     }
 
-    if (prim_type == PRIM_TYPE_TEXRECT || (prim_type == PRIM_TYPE_TRI && state->render_tile_on))
-    {
+    if (prim_type == PRIM_TYPE_TEXRECT || (prim_type == PRIM_TYPE_TRI && state->render_tile_on)) {
         chk_render_tile(state, tile);
-        if (uses_texel1)
-        {
+        if (uses_texel1) {
             if (tile == 7) // TODO warning? don't bother?
                 Note(gfxd_vprintf, "TEXEL0 was tile 7 so TEXEL1 is sourced from tile 0");
             chk_render_tile(state, (tile + 1) & 7);
@@ -2180,8 +2092,7 @@ chk_render_primitive (gfx_state_t *state, enum prim_type prim_type, int tile)
 }
 
 static int
-chk_DPFillTriangle (gfx_state_t *state, int tnum, int v0, int v1, int v2, int flag)
-{
+chk_DPFillTriangle(gfx_state_t *state, int tnum, int v0, int v1, int v2, int flag) {
     int last_loaded_vtx_num = state->last_loaded_vtx_num;
 
     // TODO this is often OK and even wanted for optimized rendering, this should be changed to use a stack-based
@@ -2192,8 +2103,7 @@ chk_DPFillTriangle (gfx_state_t *state, int tnum, int v0, int v1, int v2, int fl
 
     ARG_CHECK(state, v0 < VTX_CACHE_SIZE && v1 < VTX_CACHE_SIZE && v2 < VTX_CACHE_SIZE, GW_TRI_VTX_OOB, tnum);
 
-    if (state->render_tile_on)
-    {
+    if (state->render_tile_on) {
         // This is only a warning as a textured triangle will pass an inverse W either way, so no garbage gets read
         ARG_CHECK(state, OTHERMODE_VAL(state, hi, TEXTPERSP) == G_TP_PERSP, GW_TRI_TXTR_NOPERSP);
     }
@@ -2214,12 +2124,11 @@ chk_DPFillTriangle (gfx_state_t *state, int tnum, int v0, int v1, int v2, int fl
 }
 
 static int
-chk_SP1Quadrangle (gfx_state_t *state)
-{
-    int v0 = gfxd_arg_value(0)->i;
-    int v1 = gfxd_arg_value(1)->i;
-    int v2 = gfxd_arg_value(2)->i;
-    int v3 = gfxd_arg_value(3)->i;
+chk_SP1Quadrangle(gfx_state_t *state) {
+    int v0   = gfxd_arg_value(0)->i;
+    int v1   = gfxd_arg_value(1)->i;
+    int v2   = gfxd_arg_value(2)->i;
+    int v3   = gfxd_arg_value(3)->i;
     int flag = gfxd_arg_value(4)->i;
 
     chk_DPFillTriangle(state, 1, v0, v1, v2, flag);
@@ -2228,16 +2137,15 @@ chk_SP1Quadrangle (gfx_state_t *state)
 }
 
 static int
-chk_SP2Triangles (gfx_state_t *state)
-{
-    int v00 = gfxd_arg_value(0)->i;
-    int v01 = gfxd_arg_value(1)->i;
-    int v02 = gfxd_arg_value(2)->i;
+chk_SP2Triangles(gfx_state_t *state) {
+    int v00   = gfxd_arg_value(0)->i;
+    int v01   = gfxd_arg_value(1)->i;
+    int v02   = gfxd_arg_value(2)->i;
     int flag0 = gfxd_arg_value(3)->i;
 
-    int v10 = gfxd_arg_value(4)->i;
-    int v11 = gfxd_arg_value(5)->i;
-    int v12 = gfxd_arg_value(6)->i;
+    int v10   = gfxd_arg_value(4)->i;
+    int v11   = gfxd_arg_value(5)->i;
+    int v12   = gfxd_arg_value(6)->i;
     int flag1 = gfxd_arg_value(7)->i;
 
     chk_DPFillTriangle(state, 1, v00, v01, v02, flag0);
@@ -2246,11 +2154,10 @@ chk_SP2Triangles (gfx_state_t *state)
 }
 
 static int
-chk_SP1Triangle (gfx_state_t *state)
-{
-    int v0 = gfxd_arg_value(0)->i;
-    int v1 = gfxd_arg_value(1)->i;
-    int v2 = gfxd_arg_value(2)->i;
+chk_SP1Triangle(gfx_state_t *state) {
+    int v0   = gfxd_arg_value(0)->i;
+    int v1   = gfxd_arg_value(1)->i;
+    int v2   = gfxd_arg_value(2)->i;
     int flag = gfxd_arg_value(3)->i;
 
     chk_DPFillTriangle(state, 1, v0, v1, v2, flag);
@@ -2258,10 +2165,9 @@ chk_SP1Triangle (gfx_state_t *state)
 }
 
 static int
-chk_SPLine3D (gfx_state_t *state)
-{
-    int v0 = gfxd_arg_value(0)->i;
-    int v1 = gfxd_arg_value(1)->i;
+chk_SPLine3D(gfx_state_t *state) {
+    int v0   = gfxd_arg_value(0)->i;
+    int v1   = gfxd_arg_value(1)->i;
     int flag = gfxd_arg_value(2)->i;
 
     chk_DPFillTriangle(state, 1, v0, v0, v1, flag);
@@ -2269,11 +2175,10 @@ chk_SPLine3D (gfx_state_t *state)
 }
 
 static int
-chk_SPLineW3D (gfx_state_t *state)
-{
-    int v0 = gfxd_arg_value(0)->i;
-    int v1 = gfxd_arg_value(1)->i;
-    int wd = gfxd_arg_value(2)->i;
+chk_SPLineW3D(gfx_state_t *state) {
+    int v0   = gfxd_arg_value(0)->i;
+    int v1   = gfxd_arg_value(1)->i;
+    int wd   = gfxd_arg_value(2)->i;
     int flag = gfxd_arg_value(3)->i;
 
     chk_DPFillTriangle(state, 1, v0, v0, v1, flag);
@@ -2281,8 +2186,7 @@ chk_SPLineW3D (gfx_state_t *state)
 }
 
 static int
-chk_DPFillRectangle (gfx_state_t *state)
-{
+chk_DPFillRectangle(gfx_state_t *state) {
     qu102_t ulx = gfxd_arg_value(0)->u;
     qu102_t uly = gfxd_arg_value(1)->u;
     qu102_t lrx = gfxd_arg_value(2)->u;
@@ -2294,11 +2198,10 @@ chk_DPFillRectangle (gfx_state_t *state)
 }
 
 static int
-chk_DPSetCombine (gfx_state_t *state)
-{
+chk_DPSetCombine(gfx_state_t *state) {
     uint32_t *cc_data = (uint32_t *)(gfxd_macro_data() + gfxd_macro_offset());
-    uint32_t cc_hi = BSWAP32(cc_data[0]);
-    uint32_t cc_lo = BSWAP32(cc_data[1]);
+    uint32_t cc_hi    = BSWAP32(cc_data[0]);
+    uint32_t cc_lo    = BSWAP32(cc_data[1]);
 
     CHECK_PIPESYNC(state);
 
@@ -2310,8 +2213,7 @@ chk_DPSetCombine (gfx_state_t *state)
 }
 
 static int
-chk_geometrymode (gfx_state_t *state, uint32_t clear, uint32_t set)
-{
+chk_geometrymode(gfx_state_t *state, uint32_t clear, uint32_t set) {
     state->geometry_mode &= ~clear;
     state->geometry_mode |= set;
 
@@ -2321,8 +2223,7 @@ chk_geometrymode (gfx_state_t *state, uint32_t clear, uint32_t set)
 }
 
 static int
-chk_SPGeometryMode (gfx_state_t *state)
-{
+chk_SPGeometryMode(gfx_state_t *state) {
     uint32_t clear = gfxd_arg_value(0)->u;
     uint32_t set   = gfxd_arg_value(1)->u;
 
@@ -2330,8 +2231,7 @@ chk_SPGeometryMode (gfx_state_t *state)
 }
 
 static int
-chk_SPLoadGeometryMode (gfx_state_t *state)
-{
+chk_SPLoadGeometryMode(gfx_state_t *state) {
     uint32_t clear = 0xFFFFFFFF;
     uint32_t set   = gfxd_arg_value(0)->u;
 
@@ -2339,8 +2239,7 @@ chk_SPLoadGeometryMode (gfx_state_t *state)
 }
 
 static int
-chk_SPSetGeometryMode (gfx_state_t *state)
-{
+chk_SPSetGeometryMode(gfx_state_t *state) {
     uint32_t clear = 0;
     uint32_t set   = gfxd_arg_value(0)->u;
 
@@ -2348,8 +2247,7 @@ chk_SPSetGeometryMode (gfx_state_t *state)
 }
 
 static int
-chk_SPClearGeometryMode (gfx_state_t *state)
-{
+chk_SPClearGeometryMode(gfx_state_t *state) {
     uint32_t clear = gfxd_arg_value(0)->u;
     uint32_t set   = 0;
 
@@ -2357,16 +2255,14 @@ chk_SPClearGeometryMode (gfx_state_t *state)
 }
 
 static int
-chk_othermode (gfx_state_t *state)
-{
+chk_othermode(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
     bl_decode(&state->bl, OTHERMODE_VAL(state, lo, RENDERMODE));
     return 0;
 }
 
 static int
-chk_DPPipelineMode (gfx_state_t *state)
-{
+chk_DPPipelineMode(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(PIPELINE);
@@ -2375,8 +2271,7 @@ chk_DPPipelineMode (gfx_state_t *state)
 }
 
 static int
-chk_DPSetAlphaDither (gfx_state_t *state)
-{
+chk_DPSetAlphaDither(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(ALPHADITHER);
@@ -2385,8 +2280,7 @@ chk_DPSetAlphaDither (gfx_state_t *state)
 }
 
 static int
-chk_DPSetColorDither (gfx_state_t *state)
-{
+chk_DPSetColorDither(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(RGBDITHER);
@@ -2395,8 +2289,7 @@ chk_DPSetColorDither (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTextureConvert (gfx_state_t *state)
-{
+chk_DPSetTextureConvert(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTCONV);
@@ -2405,8 +2298,7 @@ chk_DPSetTextureConvert (gfx_state_t *state)
 }
 
 static int
-chk_DPSetCycleType (gfx_state_t *state)
-{
+chk_DPSetCycleType(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(CYCLETYPE);
@@ -2415,8 +2307,7 @@ chk_DPSetCycleType (gfx_state_t *state)
 }
 
 static int
-chk_DPSetCombineKey (gfx_state_t *state)
-{
+chk_DPSetCombineKey(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(COMBKEY);
@@ -2425,8 +2316,7 @@ chk_DPSetCombineKey (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTextureDetail (gfx_state_t *state)
-{
+chk_DPSetTextureDetail(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTDETAIL);
@@ -2435,8 +2325,7 @@ chk_DPSetTextureDetail (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTextureFilter (gfx_state_t *state)
-{
+chk_DPSetTextureFilter(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTFILT);
@@ -2445,8 +2334,7 @@ chk_DPSetTextureFilter (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTextureLOD (gfx_state_t *state)
-{
+chk_DPSetTextureLOD(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTLOD);
@@ -2455,8 +2343,7 @@ chk_DPSetTextureLOD (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTextureLUT (gfx_state_t *state)
-{
+chk_DPSetTextureLUT(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTLUT);
@@ -2465,8 +2352,7 @@ chk_DPSetTextureLUT (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTexturePersp (gfx_state_t *state)
-{
+chk_DPSetTexturePersp(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_hi &= (~0) & ~MDMASK(TEXTPERSP);
@@ -2475,8 +2361,7 @@ chk_DPSetTexturePersp (gfx_state_t *state)
 }
 
 static int
-chk_DPSetAlphaCompare (gfx_state_t *state)
-{
+chk_DPSetAlphaCompare(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_lo &= (~0) & ~MDMASK(ALPHACOMPARE);
@@ -2485,8 +2370,7 @@ chk_DPSetAlphaCompare (gfx_state_t *state)
 }
 
 static int
-chk_DPSetDepthSource (gfx_state_t *state)
-{
+chk_DPSetDepthSource(gfx_state_t *state) {
     unsigned mode = gfxd_arg_value(0)->u;
 
     state->othermode_lo &= (~0) & ~MDMASK(ZSRCSEL);
@@ -2495,8 +2379,7 @@ chk_DPSetDepthSource (gfx_state_t *state)
 }
 
 static int
-chk_DPSetRenderMode (gfx_state_t *state)
-{
+chk_DPSetRenderMode(gfx_state_t *state) {
     unsigned mode1 = gfxd_arg_value(0)->u;
     unsigned mode2 = gfxd_arg_value(1)->u;
 
@@ -2508,10 +2391,9 @@ chk_DPSetRenderMode (gfx_state_t *state)
 }
 
 static int
-chk_SPSetOtherModeHi (gfx_state_t *state)
-{
-    int sft = gfxd_arg_value(0)->i;
-    int len = gfxd_arg_value(1)->i;
+chk_SPSetOtherModeHi(gfx_state_t *state) {
+    int sft       = gfxd_arg_value(0)->i;
+    int len       = gfxd_arg_value(1)->i;
     unsigned mode = gfxd_arg_value(2)->u;
     unsigned mask = ((1 << len) - 1) << sft;
 
@@ -2521,10 +2403,9 @@ chk_SPSetOtherModeHi (gfx_state_t *state)
 }
 
 static int
-chk_SPSetOtherModeLo (gfx_state_t *state)
-{
-    int sft = gfxd_arg_value(0)->i;
-    int len = gfxd_arg_value(1)->i;
+chk_SPSetOtherModeLo(gfx_state_t *state) {
+    int sft       = gfxd_arg_value(0)->i;
+    int len       = gfxd_arg_value(1)->i;
     unsigned mode = gfxd_arg_value(2)->u;
     unsigned mask = ((1 << len) - 1) << sft;
 
@@ -2534,16 +2415,14 @@ chk_SPSetOtherModeLo (gfx_state_t *state)
 }
 
 static int
-chk_SPSetOtherMode (gfx_state_t *state)
-{
-    int opc = gfxd_arg_value(0)->i;
-    int sft = gfxd_arg_value(1)->i;
-    int len = gfxd_arg_value(2)->i;
+chk_SPSetOtherMode(gfx_state_t *state) {
+    int opc       = gfxd_arg_value(0)->i;
+    int sft       = gfxd_arg_value(1)->i;
+    int len       = gfxd_arg_value(2)->i;
     unsigned mode = gfxd_arg_value(3)->u;
     unsigned mask = ((1 << len) - 1) << sft;
 
-    switch (opc)
-    {
+    switch (opc) {
         case G_SETOTHERMODE_H:
             state->othermode_hi &= (~0) & ~mask;
             state->othermode_hi |= mode & mask;
@@ -2559,8 +2438,7 @@ chk_SPSetOtherMode (gfx_state_t *state)
 }
 
 static int
-chk_DPSetOtherMode (gfx_state_t *state)
-{
+chk_DPSetOtherMode(gfx_state_t *state) {
     uint32_t hi = gfxd_arg_value(0)->u;
     uint32_t lo = gfxd_arg_value(1)->u;
 
@@ -2569,13 +2447,12 @@ chk_DPSetOtherMode (gfx_state_t *state)
     return chk_othermode(state);
 }
 
-#define TMEM_SIZE 0x1000
+#define TMEM_SIZE            0x1000
 #define LOADBLOCK_MAX_TEXELS 2048 // trying to load more than this amount of texels loads nothing
 
 static int
-chk_DPLoadBlock (gfx_state_t *state)
-{
-    int tile = gfxd_arg_value(0)->i;
+chk_DPLoadBlock(gfx_state_t *state) {
+    int tile     = gfxd_arg_value(0)->i;
     unsigned uls = gfxd_arg_value(1)->u;
     unsigned ult = gfxd_arg_value(2)->u;
     unsigned lrs = gfxd_arg_value(3)->u;
@@ -2586,9 +2463,8 @@ chk_DPLoadBlock (gfx_state_t *state)
     CHECK_LOADSYNC(state);
 
     uint32_t timg_phys_low = state->last_timg.addr & 0b111111;
-    uint32_t line_texels = lrs - uls + 1;
-    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b
-              || (line_texels * G_SIZ_BITS(state->last_timg.siz) < 58 * 8), GW_BAD_TIMG_ALIGNMENT);
+    uint32_t line_texels   = lrs - uls + 1;
+    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b || (line_texels * G_SIZ_BITS(state->last_timg.siz) < 58 * 8), GW_BAD_TIMG_ALIGNMENT);
 
     ARG_CHECK(state, line_texels <= LOADBLOCK_MAX_TEXELS, GW_LOADBLOCK_TOO_MANY_TEXELS);
 
@@ -2599,8 +2475,7 @@ chk_DPLoadBlock (gfx_state_t *state)
 
     ARG_CHECK(state, state->last_timg.siz != G_IM_SIZ_4b, GW_TIMG_LOAD_4B);
     ARG_CHECK(state, tile_desc != NULL, GW_TILEDESC_BAD);
-    if (tile_desc != NULL)
-    {
+    if (tile_desc != NULL) {
 
         ARG_CHECK(state, tile_desc->fmt == state->last_timg.fmt && tile_desc->siz == state->last_timg.siz,
                   GW_TIMG_TILE_LOAD_NONMATCHING);
@@ -2616,9 +2491,8 @@ chk_DPLoadBlock (gfx_state_t *state)
 }
 
 static int
-chk_DPLoadTile (gfx_state_t *state)
-{
-    int tile = gfxd_arg_value(0)->i;
+chk_DPLoadTile(gfx_state_t *state) {
+    int tile     = gfxd_arg_value(0)->i;
     unsigned uls = gfxd_arg_value(1)->u;
     unsigned ult = gfxd_arg_value(2)->u;
     unsigned lrs = gfxd_arg_value(3)->u;
@@ -2629,9 +2503,8 @@ chk_DPLoadTile (gfx_state_t *state)
     CHECK_LOADSYNC(state);
 
     uint32_t timg_phys_low = state->last_timg.addr & 0b111111;
-    uint32_t line_texels = lrs - uls + 1;
-    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b
-              || (line_texels * G_SIZ_BITS(state->last_timg.siz) / 8 < 58), GW_BAD_TIMG_ALIGNMENT);
+    uint32_t line_texels   = lrs - uls + 1;
+    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b || (line_texels * G_SIZ_BITS(state->last_timg.siz) / 8 < 58), GW_BAD_TIMG_ALIGNMENT);
 
     ARG_CHECK(state, state->last_timg.siz != G_IM_SIZ_4b, GW_TIMG_LOAD_4B);
 
@@ -2640,8 +2513,7 @@ chk_DPLoadTile (gfx_state_t *state)
     // load_busy = true;
 
     ARG_CHECK(state, tile_desc != NULL, GW_TILEDESC_BAD);
-    if (tile_desc != NULL)
-    {
+    if (tile_desc != NULL) {
         tile_desc->uls = uls;
         tile_desc->ult = ult;
         tile_desc->lrs = lrs;
@@ -2651,21 +2523,20 @@ chk_DPLoadTile (gfx_state_t *state)
 }
 
 static int
-chk_DPLoadTLUTCmd (gfx_state_t *state)
-{
+chk_DPLoadTLUTCmd(gfx_state_t *state) {
     uint32_t *ltlut_data = (uint32_t *)gfxd_macro_data();
-    uint32_t ltlut_hi = BSWAP32(ltlut_data[0]);
-    uint32_t ltlut_lo = BSWAP32(ltlut_data[1]);
+    uint32_t ltlut_hi    = BSWAP32(ltlut_data[0]);
+    uint32_t ltlut_lo    = BSWAP32(ltlut_data[1]);
 
     // LoadTLUTCmd actually has more fields, it's the same command format as LoadTile
     // however the macros provided for this command by the SDK leave most as 0.
-    int tile = SHIFTR(ltlut_lo, 3, 24);
+    int tile    = SHIFTR(ltlut_lo, 3, 24);
     qu102_t uls = SHIFTR(ltlut_hi, 12, 12);
-    qu102_t ult = SHIFTR(ltlut_hi, 12,  0);
+    qu102_t ult = SHIFTR(ltlut_hi, 12, 0);
     qu102_t lrs = SHIFTR(ltlut_lo, 12, 12);
-    qu102_t lrt = SHIFTR(ltlut_lo, 12,  0);
+    qu102_t lrt = SHIFTR(ltlut_lo, 12, 0);
 
-    int count = lrs >> 2; // count here is actually count - 1
+    int count                    = lrs >> 2; // count here is actually count - 1
     tile_descriptor_t *tile_desc = get_tile_desc(state, tile);
 
     CHECK_LOADSYNC(state);
@@ -2677,22 +2548,19 @@ chk_DPLoadTLUTCmd (gfx_state_t *state)
     ARG_CHECK(state, count < 256, GW_TLUT_TOO_LARGE);
 
     uint32_t timg_phys_low = state->last_timg.addr & 0x3F;
-    uint32_t line_texels = count + 1;
-    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b
-              || (line_texels * G_SIZ_BITS(state->last_timg.siz) / 8 < 58), GW_BAD_TIMG_ALIGNMENT);
+    uint32_t line_texels   = count + 1;
+    ARG_CHECK(state, timg_phys_low == 0 || timg_phys_low >= 8 || state->last_timg.siz == G_IM_SIZ_4b || (line_texels * G_SIZ_BITS(state->last_timg.siz) / 8 < 58), GW_BAD_TIMG_ALIGNMENT);
 
     ARG_CHECK(state, state->last_timg.siz != G_IM_SIZ_4b, GW_TIMG_LOAD_4B);
 
     int timg_fmtsiz = FMT_SIZ(state->last_timg.fmt, state->last_timg.siz);
-    ARG_CHECK(state, timg_fmtsiz == FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b)
-              || timg_fmtsiz == FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_16b), GW_TLUT_BAD_FMT);
+    ARG_CHECK(state, timg_fmtsiz == FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b) || timg_fmtsiz == FMT_SIZ(G_IM_FMT_IA, G_IM_SIZ_16b), GW_TLUT_BAD_FMT);
 
     state->pipe_busy = true;
     // load_busy = true;
 
     ARG_CHECK(state, tile_desc != NULL, GW_TILEDESC_BAD);
-    if (tile_desc != NULL)
-    {
+    if (tile_desc != NULL) {
         ARG_CHECK(state, tile_desc->tmem >= 0x100, GW_TLUT_BAD_TMEM_ADDR);
 
         tile_desc->uls = uls;
@@ -2704,24 +2572,21 @@ chk_DPLoadTLUTCmd (gfx_state_t *state)
 }
 
 static int
-chk_DPPipeSync (gfx_state_t *state)
-{
+chk_DPPipeSync(gfx_state_t *state) {
     ARG_CHECK(state, state->pipe_busy, GW_SUPERFLUOUS_PIPESYNC);
     state->pipe_busy = false;
     return 0;
 }
 
 static int
-chk_DPLoadSync (gfx_state_t *state)
-{
+chk_DPLoadSync(gfx_state_t *state) {
     ARG_CHECK(state, state->load_busy, GW_SUPERFLUOUS_LOADSYNC);
     state->load_busy = false;
     return 0;
 }
 
 static int
-chk_DPTileSync (gfx_state_t *state)
-{
+chk_DPTileSync(gfx_state_t *state) {
     // tilesync will sync all tile descrptiors, it's hard to knowif a tilesync is superfluous
     // (doesn't help that it's not clear when a tilesync should even be done)
 
@@ -2732,8 +2597,7 @@ chk_DPTileSync (gfx_state_t *state)
 }
 
 static int
-chk_DPSetEnvColor (gfx_state_t *state)
-{
+chk_DPSetEnvColor(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2742,8 +2606,7 @@ chk_DPSetEnvColor (gfx_state_t *state)
 }
 
 static int
-chk_DPSetFogColor (gfx_state_t *state)
-{
+chk_DPSetFogColor(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2752,8 +2615,7 @@ chk_DPSetFogColor (gfx_state_t *state)
 }
 
 static int
-chk_DPSetBlendColor (gfx_state_t *state)
-{
+chk_DPSetBlendColor(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2762,29 +2624,26 @@ chk_DPSetBlendColor (gfx_state_t *state)
 }
 
 static int
-chk_DPSetFillColor (gfx_state_t *state)
-{
+chk_DPSetFillColor(gfx_state_t *state) {
     uint32_t color = gfxd_arg_value(0)->u;
 
     CHECK_PIPESYNC(state);
 
-    state->fill_color = color;
+    state->fill_color     = color;
     state->fill_color_set = true;
 
     return 0;
 }
 
 static int
-chk_DPSetPrimColor (gfx_state_t *state)
-{
+chk_DPSetPrimColor(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_DPSetTile (gfx_state_t *state)
-{
+chk_DPSetTile(gfx_state_t *state) {
     int fmt       = gfxd_arg_value(0)->i;
     int siz       = gfxd_arg_value(1)->i;
     int line      = gfxd_arg_value(2)->i;
@@ -2814,43 +2673,39 @@ chk_DPSetTile (gfx_state_t *state)
 
     // TODO more checks
 
-    if (tile_desc != NULL)
-    {
-        tile_desc->fmt = fmt;
-        tile_desc->siz = siz;
-        tile_desc->line = line;
-        tile_desc->tmem = tmem;
+    if (tile_desc != NULL) {
+        tile_desc->fmt     = fmt;
+        tile_desc->siz     = siz;
+        tile_desc->line    = line;
+        tile_desc->tmem    = tmem;
         tile_desc->palette = pal;
-        tile_desc->cmt = cmt;
-        tile_desc->maskt = maskt;
-        tile_desc->shiftt = shiftt;
-        tile_desc->cms = cms;
-        tile_desc->masks = masks;
-        tile_desc->shifts = shifts;
+        tile_desc->cmt     = cmt;
+        tile_desc->maskt   = maskt;
+        tile_desc->shiftt  = shiftt;
+        tile_desc->cms     = cms;
+        tile_desc->masks   = masks;
+        tile_desc->shifts  = shifts;
     }
     return 0;
 }
 
 static int
-chk_Invalid (gfx_state_t *state)
-{
+chk_Invalid(gfx_state_t *state) {
     WARNING_ERROR(state, GW_INVALID_GFX_CMD);
     return 0;
 }
 
 static int
-chk_DPFullSync (gfx_state_t *state)
-{
+chk_DPFullSync(gfx_state_t *state) {
     state->pipe_busy = false;
     memset(state->tile_busy, 0, sizeof(state->tile_busy));
     state->load_busy = false;
-    state->fullsync = true;
+    state->fullsync  = true;
     return 0;
 }
 
 static int
-chk_DPSetConvert (gfx_state_t *state)
-{
+chk_DPSetConvert(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2859,8 +2714,7 @@ chk_DPSetConvert (gfx_state_t *state)
 }
 
 static int
-chk_DPSetKeyGB (gfx_state_t *state)
-{
+chk_DPSetKeyGB(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2869,8 +2723,7 @@ chk_DPSetKeyGB (gfx_state_t *state)
 }
 
 static int
-chk_DPSetKeyR (gfx_state_t *state)
-{
+chk_DPSetKeyR(gfx_state_t *state) {
     CHECK_PIPESYNC(state);
 
     // TODO
@@ -2879,8 +2732,7 @@ chk_DPSetKeyR (gfx_state_t *state)
 }
 
 static uint8_t
-dz_compress (int dz)
-{
+dz_compress(int dz) {
     // RDP-accurate integer log2, guaranteed correct only for powers of 2.
 
     int val = 0;
@@ -2896,8 +2748,7 @@ dz_compress (int dz)
 }
 
 static uint8_t
-integer_log2 (int x)
-{
+integer_log2(int x) {
     uint8_t log = 0;
     while (x >>= 1)
         log++;
@@ -2905,9 +2756,8 @@ integer_log2 (int x)
 }
 
 static int
-chk_DPSetPrimDepth (gfx_state_t *state)
-{
-    uint16_t z = (uint16_t)gfxd_arg_value(0)->i;
+chk_DPSetPrimDepth(gfx_state_t *state) {
+    uint16_t z  = (uint16_t)gfxd_arg_value(0)->i;
     uint16_t dz = (uint16_t)gfxd_arg_value(1)->i;
 
     // Compute the fast log2 of dz that hardware uses
@@ -2921,8 +2771,7 @@ chk_DPSetPrimDepth (gfx_state_t *state)
 }
 
 static int
-chk_scissor (gfx_state_t *state, int mode, qu102_t ulx, qu102_t uly, qu102_t lrx, qu102_t lry)
-{
+chk_scissor(gfx_state_t *state, int mode, qu102_t ulx, qu102_t uly, qu102_t lrx, qu102_t lry) {
     state->scissor_set = true;
 
     ARG_CHECK(state, lrx > ulx && lry > uly, GW_SCISSOR_REGION_EMPTY);
@@ -2938,9 +2787,8 @@ chk_scissor (gfx_state_t *state, int mode, qu102_t ulx, qu102_t uly, qu102_t lrx
 }
 
 static int
-chk_DPSetScissorFrac (gfx_state_t *state)
-{
-    int mode = gfxd_arg_value(0)->i;
+chk_DPSetScissorFrac(gfx_state_t *state) {
+    int mode    = gfxd_arg_value(0)->i;
     qu102_t ulx = gfxd_arg_value(1)->u;
     qu102_t uly = gfxd_arg_value(2)->u;
     qu102_t lrx = gfxd_arg_value(3)->u;
@@ -2950,9 +2798,8 @@ chk_DPSetScissorFrac (gfx_state_t *state)
 }
 
 static int
-chk_DPSetScissor (gfx_state_t *state)
-{
-    int mode = gfxd_arg_value(0)->i;
+chk_DPSetScissor(gfx_state_t *state) {
+    int mode     = gfxd_arg_value(0)->i;
     unsigned ulx = gfxd_arg_value(1)->u;
     unsigned uly = gfxd_arg_value(2)->u;
     unsigned lrx = gfxd_arg_value(3)->u;
@@ -2962,9 +2809,8 @@ chk_DPSetScissor (gfx_state_t *state)
 }
 
 static int
-chk_DPSetTileSize (gfx_state_t *state)
-{
-    int tile = gfxd_arg_value(0)->i;
+chk_DPSetTileSize(gfx_state_t *state) {
+    int tile    = gfxd_arg_value(0)->i;
     qu102_t uls = gfxd_arg_value(1)->u;
     qu102_t ult = gfxd_arg_value(2)->u;
     qu102_t lrs = gfxd_arg_value(3)->u;
@@ -2976,8 +2822,7 @@ chk_DPSetTileSize (gfx_state_t *state)
 
     ARG_CHECK(state, tile_desc != NULL, GW_TILEDESC_BAD);
 
-    if(tile_desc != NULL)
-    {
+    if (tile_desc != NULL) {
         tile_desc->uls = uls;
         tile_desc->ult = ult;
         tile_desc->lrs = lrs;
@@ -2987,12 +2832,11 @@ chk_DPSetTileSize (gfx_state_t *state)
 }
 
 static int
-chk_SPBranchLessZraw (gfx_state_t *state)
-{
+chk_SPBranchLessZraw(gfx_state_t *state) {
     // TODO
     uint32_t branchdl = gfxd_arg_value(0)->u;
-    int vtx = gfxd_arg_value(1)->i;
-    int zval = gfxd_arg_value(2)->i;
+    int vtx           = gfxd_arg_value(1)->i;
+    int zval          = gfxd_arg_value(2)->i;
 
     uint32_t branchdl_phys = segmented_to_physical(state, branchdl);
 
@@ -3000,8 +2844,7 @@ chk_SPBranchLessZraw (gfx_state_t *state)
 
     // TODO this can be either a comparison with w or depth depending on whether the ucode is ZEX or not
     // if (vtx_depths[vtx] > 0x03FF || vtx_depths[vtx] <= zval)
-    if (state->vtx_w[vtx] < (float)zval)
-    {
+    if (state->vtx_w[vtx] < (float)zval) {
         Note(gfxd_vprintf, "BranchLessZ success");
         state->gfx_addr = branchdl_phys - sizeof(Gfx);
     }
@@ -3009,24 +2852,21 @@ chk_SPBranchLessZraw (gfx_state_t *state)
 }
 
 static int
-chk_SPClipRatio (gfx_state_t *state)
-{
+chk_SPClipRatio(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_fog (int fm, int fo)
-{
+chk_fog(int fm, int fo) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPFogFactor (gfx_state_t *state)
-{
+chk_SPFogFactor(gfx_state_t *state) {
     int fm = gfxd_arg_value(0)->i;
     int fo = gfxd_arg_value(1)->i;
 
@@ -3034,8 +2874,7 @@ chk_SPFogFactor (gfx_state_t *state)
 }
 
 static int
-chk_SPFogPosition (gfx_state_t *state)
-{
+chk_SPFogPosition(gfx_state_t *state) {
     int min = gfxd_arg_value(0)->i;
     int max = gfxd_arg_value(1)->i;
 
@@ -3046,9 +2885,8 @@ chk_SPFogPosition (gfx_state_t *state)
 }
 
 static int
-chk_SPForceMatrix (gfx_state_t *state)
-{
-    uint32_t mptr = gfxd_arg_value(0)->u;
+chk_SPForceMatrix(gfx_state_t *state) {
+    uint32_t mptr      = gfxd_arg_value(0)->u;
     uint32_t mptr_phys = segmented_to_physical(state, mptr);
 
     chk_Range(state, mptr_phys, sizeof(Mtx));
@@ -3059,22 +2897,18 @@ chk_SPForceMatrix (gfx_state_t *state)
 }
 
 static int
-chk_SPInsertMatrix (gfx_state_t *state)
-{
+chk_SPInsertMatrix(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-new_ucode (gfx_state_t *state, uint32_t uctext_start)
-{
+new_ucode(gfx_state_t *state, uint32_t uctext_start) {
     gfx_ucode_registry_t *ucode_entry;
 
-    for (ucode_entry = state->ucodes; ucode_entry->ucode != NULL; ucode_entry++)
-    {
-        if ((uctext_start & ~KSEG_MASK) == (ucode_entry->text_start & ~KSEG_MASK))
-        {
+    for (ucode_entry = state->ucodes; ucode_entry->ucode != NULL; ucode_entry++) {
+        if ((uctext_start & ~KSEG_MASK) == (ucode_entry->text_start & ~KSEG_MASK)) {
             state->next_ucode = ucode_entry->ucode;
             return 0;
         }
@@ -3087,8 +2921,7 @@ new_ucode (gfx_state_t *state, uint32_t uctext_start)
 #define UCODE_DATA_SIZE 0x800
 
 static int
-chk_LoadUcode (gfx_state_t *state)
-{
+chk_LoadUcode(gfx_state_t *state) {
     unsigned uc_start = gfxd_arg_value(0)->u;
     unsigned uc_dsize = gfxd_arg_value(1)->u;
 
@@ -3100,11 +2933,10 @@ chk_LoadUcode (gfx_state_t *state)
 }
 
 static int
-chk_SPLoadUcodeEx (gfx_state_t *state)
-{
-    unsigned uc_start = gfxd_arg_value(0)->u;
+chk_SPLoadUcodeEx(gfx_state_t *state) {
+    unsigned uc_start  = gfxd_arg_value(0)->u;
     unsigned uc_dstart = gfxd_arg_value(1)->u;
-    unsigned uc_dsize = gfxd_arg_value(2)->u;
+    unsigned uc_dsize  = gfxd_arg_value(2)->u;
 
     uc_start &= 0x00FFFFFF;
     uc_dstart &= 0x00FFFFFF;
@@ -3116,9 +2948,8 @@ chk_SPLoadUcodeEx (gfx_state_t *state)
 }
 
 static int
-chk_SPLoadUcode (gfx_state_t *state)
-{
-    unsigned uc_start = gfxd_arg_value(0)->u;
+chk_SPLoadUcode(gfx_state_t *state) {
+    unsigned uc_start  = gfxd_arg_value(0)->u;
     unsigned uc_dstart = gfxd_arg_value(1)->u;
 
     uc_start &= 0x00FFFFFF;
@@ -3131,9 +2962,8 @@ chk_SPLoadUcode (gfx_state_t *state)
 }
 
 static int
-chk_SPLookAtX (gfx_state_t *state)
-{
-    uint32_t l = gfxd_arg_value(0)->u;
+chk_SPLookAtX(gfx_state_t *state) {
+    uint32_t l      = gfxd_arg_value(0)->u;
     uint32_t l_phys = segmented_to_physical(state, l);
 
     chk_Range(state, l_phys, sizeof(Light));
@@ -3142,9 +2972,8 @@ chk_SPLookAtX (gfx_state_t *state)
 }
 
 static int
-chk_SPLookAtY (gfx_state_t *state)
-{
-    uint32_t l = gfxd_arg_value(0)->u;
+chk_SPLookAtY(gfx_state_t *state) {
+    uint32_t l      = gfxd_arg_value(0)->u;
     uint32_t l_phys = segmented_to_physical(state, l);
 
     chk_Range(state, l_phys, sizeof(Light));
@@ -3153,9 +2982,8 @@ chk_SPLookAtY (gfx_state_t *state)
 }
 
 static int
-chk_SPLookAt (gfx_state_t *state)
-{
-    uint32_t l = gfxd_arg_value(0)->u;
+chk_SPLookAt(gfx_state_t *state) {
+    uint32_t l      = gfxd_arg_value(0)->u;
     uint32_t l_phys = segmented_to_physical(state, l);
 
     chk_Range(state, l_phys, sizeof(LookAt));
@@ -3164,11 +2992,10 @@ chk_SPLookAt (gfx_state_t *state)
 }
 
 static int
-chk_SPModifyVertex (gfx_state_t *state)
-{
-    int vtx = gfxd_arg_value(0)->i;
+chk_SPModifyVertex(gfx_state_t *state) {
+    int vtx        = gfxd_arg_value(0)->i;
     unsigned where = gfxd_arg_value(1)->u;
-    unsigned val = gfxd_arg_value(2)->u;
+    unsigned val   = gfxd_arg_value(2)->u;
 
     ARG_CHECK(state, vtx < VTX_CACHE_SIZE, GW_MODIFYVTX_OOB);
 
@@ -3178,16 +3005,14 @@ chk_SPModifyVertex (gfx_state_t *state)
 }
 
 static int
-chk_SPPerspNormalize (gfx_state_t *state)
-{
-    int wscale = gfxd_arg_value(0)->u;
+chk_SPPerspNormalize(gfx_state_t *state) {
+    int wscale        = gfxd_arg_value(0)->u;
     state->persp_norm = ((float)wscale) / 0x10000;
     return 0;
 }
 
 static int
-chk_popmtx (gfx_state_t *state, int param, int num)
-{
+chk_popmtx(gfx_state_t *state, int param, int num) {
     ARG_CHECK(state, param == G_MTX_MODELVIEW, GW_MTX_POP_NOT_MODELVIEW);
     ARG_CHECK(state, state->matrix_stack_depth >= num, GW_MTX_STACK_UNDERFLOW);
 
@@ -3197,16 +3022,14 @@ chk_popmtx (gfx_state_t *state, int param, int num)
 }
 
 static int
-chk_SPPopMatrix (gfx_state_t *state)
-{
+chk_SPPopMatrix(gfx_state_t *state) {
     int param = gfxd_arg_value(0)->i;
 
     return chk_popmtx(state, param, 1);
 }
 
 static int
-chk_SPPopMatrixN (gfx_state_t *state)
-{
+chk_SPPopMatrixN(gfx_state_t *state) {
     int param = gfxd_arg_value(0)->i;
     int num   = gfxd_arg_value(1)->i;
 
@@ -3214,93 +3037,82 @@ chk_SPPopMatrixN (gfx_state_t *state)
 }
 
 static int
-chk_SPSetLights1 (gfx_state_t *state)
-{
+chk_SPSetLights1(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights2 (gfx_state_t *state)
-{
+chk_SPSetLights2(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights3 (gfx_state_t *state)
-{
+chk_SPSetLights3(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights4 (gfx_state_t *state)
-{
+chk_SPSetLights4(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights5 (gfx_state_t *state)
-{
+chk_SPSetLights5(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights6 (gfx_state_t *state)
-{
+chk_SPSetLights6(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetLights7 (gfx_state_t *state)
-{
+chk_SPSetLights7(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPNumLights (gfx_state_t *state)
-{
+chk_SPNumLights(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPLight (gfx_state_t *state)
-{
+chk_SPLight(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPLightColor (gfx_state_t *state)
-{
+chk_SPLightColor(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPTexture (gfx_state_t *state)
-{
+chk_SPTexture(gfx_state_t *state) {
     qu510_t sc = gfxd_arg_value(0)->i;
     qu510_t tc = gfxd_arg_value(1)->i;
-    int level = gfxd_arg_value(2)->i;
-    int tile = gfxd_arg_value(3)->i;
-    int on = gfxd_arg_value(4)->i;
+    int level  = gfxd_arg_value(2)->i;
+    int tile   = gfxd_arg_value(3)->i;
+    int on     = gfxd_arg_value(4)->i;
 
     tile_descriptor_t *tile_desc = get_tile_desc(state, tile);
 
@@ -3308,19 +3120,17 @@ chk_SPTexture (gfx_state_t *state)
 
     state->render_tile = tile;
 
-    if (tile_desc != NULL)
-    {
-        state->render_tile_on = on;
+    if (tile_desc != NULL) {
+        state->render_tile_on    = on;
         state->render_tile_level = level;
-        state->tex_s_scale = sc;
-        state->tex_t_scale = tc;
+        state->tex_s_scale       = sc;
+        state->tex_t_scale       = tc;
     }
     return 0;
 }
 
 static int
-chk_SPTextureRectangle (gfx_state_t *state)
-{
+chk_SPTextureRectangle(gfx_state_t *state) {
     qu102_t ulx  = gfxd_arg_value(0)->u;
     qu102_t uly  = gfxd_arg_value(1)->u;
     qu102_t lrx  = gfxd_arg_value(2)->u;
@@ -3341,8 +3151,7 @@ chk_SPTextureRectangle (gfx_state_t *state)
 }
 
 static int
-chk_SPTextureRectangleFlip (gfx_state_t *state)
-{
+chk_SPTextureRectangleFlip(gfx_state_t *state) {
     qu102_t ulx  = gfxd_arg_value(0)->u;
     qu102_t uly  = gfxd_arg_value(1)->u;
     qu102_t lrx  = gfxd_arg_value(2)->u;
@@ -3361,112 +3170,98 @@ chk_SPTextureRectangleFlip (gfx_state_t *state)
 }
 
 static int
-chk_BranchZ (gfx_state_t *state)
-{
+chk_BranchZ(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_DPHalf1 (gfx_state_t *state)
-{
+chk_DPHalf1(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_DPHalf2 (gfx_state_t *state)
-{
+chk_DPHalf2(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_DPWord (gfx_state_t *state)
-{
+chk_DPWord(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_MoveWd (gfx_state_t *state)
-{
+chk_MoveWd(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_MoveMem (gfx_state_t *state)
-{
+chk_MoveMem(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPDma_io (gfx_state_t *state)
-{
+chk_SPDma_io(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPDmaRead (gfx_state_t *state)
-{
+chk_SPDmaRead(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPDmaWrite (gfx_state_t *state)
-{
+chk_SPDmaWrite(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPNoOp (gfx_state_t *state)
-{
+chk_SPNoOp(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_Special3 (gfx_state_t *state)
-{
+chk_Special3(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_Special2 (gfx_state_t *state)
-{
+chk_Special2(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_Special1 (gfx_state_t *state)
-{
+chk_Special1(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPBgRectCopy (gfx_state_t *state)
-{
+chk_SPBgRectCopy(gfx_state_t *state) {
     uint32_t bg = gfxd_arg_value(0)->u;
 
     uint32_t bg_phys = segmented_to_physical(state, bg);
@@ -3477,9 +3272,8 @@ chk_SPBgRectCopy (gfx_state_t *state)
 }
 
 static int
-chk_SPBgRect1Cyc (gfx_state_t *state)
-{
-    uint32_t bg = gfxd_arg_value(0)->u;
+chk_SPBgRect1Cyc(gfx_state_t *state) {
+    uint32_t bg      = gfxd_arg_value(0)->u;
     uint32_t bg_phys = segmented_to_physical(state, bg);
 
     chk_Range(state, bg_phys, sizeof(uObjBg));
@@ -3488,33 +3282,29 @@ chk_SPBgRect1Cyc (gfx_state_t *state)
 }
 
 static int
-chk_SPObjRectangle (gfx_state_t *state)
-{
+chk_SPObjRectangle(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjRectangleR (gfx_state_t *state)
-{
+chk_SPObjRectangleR(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjSprite (gfx_state_t *state)
-{
+chk_SPObjSprite(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjMatrix (gfx_state_t *state)
-{
-    uint32_t mtx = gfxd_arg_value(0)->u;
+chk_SPObjMatrix(gfx_state_t *state) {
+    uint32_t mtx      = gfxd_arg_value(0)->u;
     uint32_t mtx_phys = segmented_to_physical(state, mtx);
 
     chk_Range(state, mtx_phys, sizeof(uObjMtx));
@@ -3523,9 +3313,8 @@ chk_SPObjMatrix (gfx_state_t *state)
 }
 
 static int
-chk_SPObjSubMatrix (gfx_state_t *state)
-{
-    uint32_t mtx = gfxd_arg_value(0)->u;
+chk_SPObjSubMatrix(gfx_state_t *state) {
+    uint32_t mtx      = gfxd_arg_value(0)->u;
     uint32_t mtx_phys = segmented_to_physical(state, mtx);
 
     chk_Range(state, mtx_phys, sizeof(uObjSubMtx));
@@ -3534,108 +3323,124 @@ chk_SPObjSubMatrix (gfx_state_t *state)
 }
 
 static int
-chk_ObjMoveMem (gfx_state_t *state)
-{
+chk_ObjMoveMem(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjRenderMode (gfx_state_t *state)
-{
+chk_SPObjRenderMode(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjLoadTxtr (gfx_state_t *state)
-{
+chk_SPObjLoadTxtr(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjLoadTxRect (gfx_state_t *state)
-{
+chk_SPObjLoadTxRect(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjLoadTxRectR (gfx_state_t *state)
-{
+chk_SPObjLoadTxRectR(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPObjLoadTxSprite (gfx_state_t *state)
-{
+chk_SPObjLoadTxSprite(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SelectDL (gfx_state_t *state)
-{
+chk_SelectDL(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSelectDL (gfx_state_t *state)
-{
+chk_SPSelectDL(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSelectBranchDL (gfx_state_t *state)
-{
+chk_SPSelectBranchDL(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_DPHalf0 (gfx_state_t *state)
-{
+chk_DPHalf0(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static int
-chk_SPSetStatus (gfx_state_t *state)
-{
+chk_SPSetStatus(gfx_state_t *state) {
     // TODO
 
     return 0;
 }
 
 static bool
-ltb_width_valid (int width, int siz)
-{
+ltb_width_valid(int width, int siz) {
     int valid_16b_widths[] =
-    {
-        4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48, 64, 72, 76, 100, 108, 128, 
-        144, 152, 164, 200, 216, 228, 256, 304, 328, 432, 456, 512, 684, 820, 912,
-    };
+        {
+            4,
+            8,
+            12,
+            16,
+            20,
+            24,
+            28,
+            32,
+            36,
+            40,
+            48,
+            64,
+            72,
+            76,
+            100,
+            108,
+            128,
+            144,
+            152,
+            164,
+            200,
+            216,
+            228,
+            256,
+            304,
+            328,
+            432,
+            456,
+            512,
+            684,
+            820,
+            912,
+        };
 
-    for (size_t i = 0; i < ARRAY_COUNT(valid_16b_widths); i++)
-    {
+    for (size_t i = 0; i < ARRAY_COUNT(valid_16b_widths); i++) {
         int nominal_width = valid_16b_widths[i];
 
-        switch (siz)
-        {
+        switch (siz) {
             case G_IM_SIZ_4b:
                 nominal_width *= 4;
                 break;
@@ -3660,16 +3465,14 @@ ltb_width_valid (int width, int siz)
  *  Returns -1 for invalid widths, 0 for impossible widths, or > 0 the maximum height for that width
  */
 static int
-max_lines (int width, int siz)
-{
+max_lines(int width, int siz) {
     // gfxd_printf("width: %d\n", width);
 
     if (width == 0)
         return -1;
 
     // Convert width to 16b
-    switch (siz)
-    {
+    switch (siz) {
         case G_IM_SIZ_4b:
             width /= 4;
             break;
@@ -3683,7 +3486,7 @@ max_lines (int width, int siz)
 
     // gfxd_printf("width (16b txls): %d\n", width);
 
-    int ldbits = G_SIZ_LDBITS(G_SIZ_LDSIZ(siz));
+    int ldbits         = G_SIZ_LDBITS(G_SIZ_LDSIZ(siz));
     int bytes_per_line = (width * ldbits) / 8;
 
     // gfxd_printf("line bytes: %d\n", bytes_per_line);
@@ -3692,7 +3495,7 @@ max_lines (int width, int siz)
         return -1; // invalid width
 
     int abs_max_lines = LOADBLOCK_MAX_TEXELS / width;
-    int max_lines = 0;
+    int max_lines     = 0;
 
     // gfxd_printf("abs max lines %d\n", abs_max_lines);
 
@@ -3701,15 +3504,13 @@ max_lines (int width, int siz)
         max_lines = abs_max_lines;
 
         // gfxd_printf("power of 2\n");
-    }
-    else
-    {   // accumulating dxt builds up small error over time for non power of 2 values,
+    } else { // accumulating dxt builds up small error over time for non power of 2 values,
         // meaning the true max lines may be less than the amount that is required
         double int_part;
         int words_per_line = bytes_per_line / 8;
-        float dxt = 2048 / (float)words_per_line;
+        float dxt          = 2048 / (float)words_per_line;
         float err_per_line = words_per_line * (1.0f - modf(dxt, &int_part));
-        max_lines = floorf(dxt / err_per_line);
+        max_lines          = floorf(dxt / err_per_line);
         if (max_lines > abs_max_lines)
             max_lines = abs_max_lines;
     }
@@ -3717,17 +3518,16 @@ max_lines (int width, int siz)
     // gfxd_printf("max lines (for load) %d\n", max_lines);
 
     // Convert the max lines to one in terms of the actual texel size
-    switch (siz)
-    {
+    switch (siz) {
         case G_IM_SIZ_4b:
             max_lines *= 4;
             break;
         case G_IM_SIZ_8b:
             max_lines *= 2;
             break;
-        //case G_IM_SIZ_32b:
-        //    max_lines /= 2;
-        //    break;
+            //case G_IM_SIZ_32b:
+            //    max_lines /= 2;
+            //    break;
     }
 
     // gfxd_printf("max lines: %d\n", max_lines);
@@ -3735,9 +3535,8 @@ max_lines (int width, int siz)
 }
 
 static int
-chk_LTB (gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int height, int pal, unsigned cms,
-         unsigned cmt, int masks, int maskt, int shifts, int shiftt)
-{
+chk_LTB(gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int height, int pal, unsigned cms,
+        unsigned cmt, int masks, int maskt, int shifts, int shiftt) {
     // ARG_CHECK(state, ltb_dims_valid(width, height, siz), "Bad width-height combination for LoadTextureBlock");
 
     int mlines = max_lines(width, siz);
@@ -3751,8 +3550,7 @@ chk_LTB (gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int hei
     //           "The width-height combination for LoadTextureBlock will cause corruption due to dxt imprecision, "
     //           "a width of %d may only have at most %d texture lines, this has %d", width, mlines, height);
 
-    if (state->options->print_textures)
-    {
+    if (state->options->print_textures) {
         tile_descriptor_t *tile_desc = get_tile_desc(state, pal);
         if (tile_desc != NULL)
             draw_last_timg(state, timg, fmt, siz, height, width, tile_desc->tmem, pal, tile_desc->lrs);
@@ -3762,8 +3560,7 @@ chk_LTB (gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int hei
 }
 
 static int
-chk_DPLoadTextureBlock (gfx_state_t *state)
-{
+chk_DPLoadTextureBlock(gfx_state_t *state) {
     uint32_t timg = gfxd_arg_value(0)->u;
     int fmt       = gfxd_arg_value(1)->i;
     int siz       = gfxd_arg_value(2)->i;
@@ -3781,8 +3578,7 @@ chk_DPLoadTextureBlock (gfx_state_t *state)
 }
 
 static int
-chk_DPLoadTextureBlock_4b (gfx_state_t *state)
-{
+chk_DPLoadTextureBlock_4b(gfx_state_t *state) {
     unsigned timg = gfxd_arg_value(0)->u;
     int fmt       = gfxd_arg_value(1)->i;
     int siz       = G_IM_SIZ_4b;
@@ -3804,184 +3600,183 @@ chk_DPLoadTextureBlock_4b (gfx_state_t *state)
  */
 
 static chk_fn chk_tbl[158] = {
-    [gfxd_Invalid]                  = chk_Invalid,
-    [gfxd_DPFillRectangle]          = chk_DPFillRectangle,
-    [gfxd_DPFullSync]               = chk_DPFullSync,
-    [gfxd_DPLoadSync]               = chk_DPLoadSync,
-    [gfxd_DPTileSync]               = chk_DPTileSync,
-    [gfxd_DPPipeSync]               = chk_DPPipeSync,
-    [gfxd_DPLoadTLUT_pal16]         = NULL,
-    [gfxd_DPLoadTLUT_pal256]        = NULL,
-    [gfxd_DPLoadMultiBlockYuvS]     = NULL,
-    [gfxd_DPLoadMultiBlockYuv]      = NULL,
-    [gfxd_DPLoadMultiBlock_4bS]     = NULL,
-    [gfxd_DPLoadMultiBlock_4b]      = NULL,
-    [gfxd_DPLoadMultiBlockS]        = NULL,
-    [gfxd_DPLoadMultiBlock]         = NULL,
-    [gfxd__DPLoadTextureBlockYuvS]  = NULL,
-    [gfxd__DPLoadTextureBlockYuv]   = NULL,
-    [gfxd__DPLoadTextureBlock_4bS]  = NULL,
-    [gfxd__DPLoadTextureBlock_4b]   = NULL,
-    [gfxd__DPLoadTextureBlockS]     = NULL,
-    [gfxd__DPLoadTextureBlock]      = NULL,
-    [gfxd_DPLoadTextureBlockYuvS]   = NULL,
-    [gfxd_DPLoadTextureBlockYuv]    = NULL,
-    [gfxd_DPLoadTextureBlock_4bS]   = NULL,
-    [gfxd_DPLoadTextureBlock_4b]    = chk_DPLoadTextureBlock_4b,
-    [gfxd_DPLoadTextureBlockS]      = NULL,
-    [gfxd_DPLoadTextureBlock]       = chk_DPLoadTextureBlock,
-    [gfxd_DPLoadMultiTileYuv]       = NULL,
-    [gfxd_DPLoadMultiTile_4b]       = NULL,
-    [gfxd_DPLoadMultiTile]          = NULL,
-    [gfxd__DPLoadTextureTileYuv]    = NULL,
-    [gfxd__DPLoadTextureTile_4b]    = NULL,
-    [gfxd__DPLoadTextureTile]       = NULL,
-    [gfxd_DPLoadTextureTileYuv]     = NULL,
-    [gfxd_DPLoadTextureTile_4b]     = NULL,
-    [gfxd_DPLoadTextureTile]        = NULL,
-    [gfxd_DPLoadBlock]              = chk_DPLoadBlock,
-    [gfxd_DPNoOp]                   = NULL,
-    [gfxd_DPNoOpTag]                = NULL,
-    [gfxd_DPNoOpTag3]               = NULL,
-    [gfxd_DPPipelineMode]           = chk_DPPipelineMode,
-    [gfxd_DPSetBlendColor]          = chk_DPSetBlendColor,
-    [gfxd_DPSetEnvColor]            = chk_DPSetEnvColor,
-    [gfxd_DPSetFillColor]           = chk_DPSetFillColor,
-    [gfxd_DPSetFogColor]            = chk_DPSetFogColor,
-    [gfxd_DPSetPrimColor]           = chk_DPSetPrimColor,
-    [gfxd_DPSetColorImage]          = chk_DPSetColorImage,
-    [gfxd_DPSetDepthImage]          = chk_DPSetDepthImage,
-    [gfxd_DPSetTextureImage]        = chk_DPSetTextureImage,
-    [gfxd_DPSetAlphaCompare]        = chk_DPSetAlphaCompare,
-    [gfxd_DPSetAlphaDither]         = chk_DPSetAlphaDither,
-    [gfxd_DPSetColorDither]         = chk_DPSetColorDither,
-    [gfxd_DPSetCombineMode]         = chk_DPSetCombine,
-    [gfxd_DPSetCombineLERP]         = chk_DPSetCombine,
-    [gfxd_DPSetConvert]             = chk_DPSetConvert,
-    [gfxd_DPSetTextureConvert]      = chk_DPSetTextureConvert,
-    [gfxd_DPSetCycleType]           = chk_DPSetCycleType,
-    [gfxd_DPSetDepthSource]         = chk_DPSetDepthSource,
-    [gfxd_DPSetCombineKey]          = chk_DPSetCombineKey,
-    [gfxd_DPSetKeyGB]               = chk_DPSetKeyGB,
-    [gfxd_DPSetKeyR]                = chk_DPSetKeyR,
-    [gfxd_DPSetPrimDepth]           = chk_DPSetPrimDepth,
-    [gfxd_DPSetRenderMode]          = chk_DPSetRenderMode,
-    [gfxd_DPSetScissor]             = chk_DPSetScissor,
-    [gfxd_DPSetScissorFrac]         = chk_DPSetScissorFrac,
-    [gfxd_DPSetTextureDetail]       = chk_DPSetTextureDetail,
-    [gfxd_DPSetTextureFilter]       = chk_DPSetTextureFilter,
-    [gfxd_DPSetTextureLOD]          = chk_DPSetTextureLOD,
-    [gfxd_DPSetTextureLUT]          = chk_DPSetTextureLUT,
-    [gfxd_DPSetTexturePersp]        = chk_DPSetTexturePersp,
-    [gfxd_DPSetTile]                = chk_DPSetTile,
-    [gfxd_DPSetTileSize]            = chk_DPSetTileSize,
-    [gfxd_SP1Triangle]              = chk_SP1Triangle,
-    [gfxd_SP2Triangles]             = chk_SP2Triangles,
-    [gfxd_SP1Quadrangle]            = chk_SP1Quadrangle,
-    [gfxd_SPBranchLessZraw]         = chk_SPBranchLessZraw,
-    [gfxd_SPBranchList]             = chk_SPBranchList,
-    [gfxd_SPClipRatio]              = chk_SPClipRatio,
-    [gfxd_SPCullDisplayList]        = chk_SPCullDisplayList,
-    [gfxd_SPDisplayList]            = chk_SPDisplayList,
-    [gfxd_SPEndDisplayList]         = chk_SPEndDisplayList,
-    [gfxd_SPFogFactor]              = chk_SPFogFactor,
-    [gfxd_SPFogPosition]            = chk_SPFogPosition,
-    [gfxd_SPForceMatrix]            = chk_SPForceMatrix,
-    [gfxd_SPSetGeometryMode]        = chk_SPSetGeometryMode,
-    [gfxd_SPClearGeometryMode]      = chk_SPClearGeometryMode,
-    [gfxd_SPLoadGeometryMode]       = chk_SPLoadGeometryMode,
-    [gfxd_SPInsertMatrix]           = chk_SPInsertMatrix,
-    [gfxd_SPLine3D]                 = chk_SPLine3D,
-    [gfxd_SPLineW3D]                = chk_SPLineW3D,
-    [gfxd_SPLoadUcode]              = chk_SPLoadUcode,
-    [gfxd_SPLookAtX]                = chk_SPLookAtX,
-    [gfxd_SPLookAtY]                = chk_SPLookAtY,
-    [gfxd_SPLookAt]                 = chk_SPLookAt,
-    [gfxd_SPMatrix]                 = chk_SPMatrix,
-    [gfxd_SPModifyVertex]           = chk_SPModifyVertex,
-    [gfxd_SPPerspNormalize]         = chk_SPPerspNormalize,
-    [gfxd_SPPopMatrix]              = chk_SPPopMatrix,
-    [gfxd_SPPopMatrixN]             = chk_SPPopMatrixN,
-    [gfxd_SPSegment]                = chk_SPSegment,
-    [gfxd_SPSetLights1]             = chk_SPSetLights1,
-    [gfxd_SPSetLights2]             = chk_SPSetLights2,
-    [gfxd_SPSetLights3]             = chk_SPSetLights3,
-    [gfxd_SPSetLights4]             = chk_SPSetLights4,
-    [gfxd_SPSetLights5]             = chk_SPSetLights5,
-    [gfxd_SPSetLights6]             = chk_SPSetLights6,
-    [gfxd_SPSetLights7]             = chk_SPSetLights7,
-    [gfxd_SPNumLights]              = chk_SPNumLights,
-    [gfxd_SPLight]                  = chk_SPLight,
-    [gfxd_SPLightColor]             = chk_SPLightColor,
-    [gfxd_SPTexture]                = chk_SPTexture,
-    [gfxd_SPTextureRectangle]       = chk_SPTextureRectangle,
-    [gfxd_SPTextureRectangleFlip]   = chk_SPTextureRectangleFlip,
-    [gfxd_SPVertex]                 = chk_SPVertex,
-    [gfxd_SPViewport]               = chk_SPViewport,
-    [gfxd_DPLoadTLUTCmd]            = chk_DPLoadTLUTCmd,
-    [gfxd_DPLoadTLUT]               = NULL,
-    [gfxd_BranchZ]                  = chk_BranchZ,
-    [gfxd_DisplayList]              = chk_DisplayList,
-    [gfxd_DPHalf1]                  = chk_DPHalf1,
-    [gfxd_DPHalf2]                  = chk_DPHalf2,
-    [gfxd_DPWord]                   = chk_DPWord,
-    [gfxd_DPLoadTile]               = chk_DPLoadTile,
-    [gfxd_SPGeometryMode]           = chk_SPGeometryMode,
-    [gfxd_SPSetOtherMode]           = chk_SPSetOtherMode,
-    [gfxd_SPSetOtherModeLo]         = chk_SPSetOtherModeLo,
-    [gfxd_SPSetOtherModeHi]         = chk_SPSetOtherModeHi,
-    [gfxd_DPSetOtherMode]           = chk_DPSetOtherMode,
-    [gfxd_MoveWd]                   = chk_MoveWd,
-    [gfxd_MoveMem]                  = chk_MoveMem,
-    [gfxd_SPDma_io]                 = chk_SPDma_io,
-    [gfxd_SPDmaRead]                = chk_SPDmaRead,
-    [gfxd_SPDmaWrite]               = chk_SPDmaWrite,
-    [gfxd_LoadUcode]                = chk_LoadUcode,
-    [gfxd_SPLoadUcodeEx]            = chk_SPLoadUcodeEx,
-    [gfxd_TexRect]                  = NULL,
-    [gfxd_TexRectFlip]              = NULL,
-    [gfxd_SPNoOp]                   = chk_SPNoOp,
-    [gfxd_Special3]                 = chk_Special3,
-    [gfxd_Special2]                 = chk_Special2,
-    [gfxd_Special1]                 = chk_Special1,
-    [gfxd_SPBgRectCopy]             = chk_SPBgRectCopy,
-    [gfxd_SPBgRect1Cyc]             = chk_SPBgRect1Cyc,
-    [gfxd_SPObjRectangle]           = chk_SPObjRectangle,
-    [gfxd_SPObjRectangleR]          = chk_SPObjRectangleR,
-    [gfxd_SPObjSprite]              = chk_SPObjSprite,
-    [gfxd_SPObjMatrix]              = chk_SPObjMatrix,
-    [gfxd_SPObjSubMatrix]           = chk_SPObjSubMatrix,
-    [gfxd_ObjMoveMem]               = chk_ObjMoveMem,
-    [gfxd_SPObjRenderMode]          = chk_SPObjRenderMode,
-    [gfxd_SPObjLoadTxtr]            = chk_SPObjLoadTxtr,
-    [gfxd_SPObjLoadTxRect]          = chk_SPObjLoadTxRect,
-    [gfxd_SPObjLoadTxRectR]         = chk_SPObjLoadTxRectR,
-    [gfxd_SPObjLoadTxSprite]        = chk_SPObjLoadTxSprite,
-    [gfxd_SelectDL]                 = chk_SelectDL,
-    [gfxd_SPSelectDL]               = chk_SPSelectDL,
-    [gfxd_SPSelectBranchDL]         = chk_SPSelectBranchDL,
-    [gfxd_DPHalf0]                  = chk_DPHalf0,
-    [gfxd_SPSetStatus]              = chk_SPSetStatus,
+    [gfxd_Invalid]                 = chk_Invalid,
+    [gfxd_DPFillRectangle]         = chk_DPFillRectangle,
+    [gfxd_DPFullSync]              = chk_DPFullSync,
+    [gfxd_DPLoadSync]              = chk_DPLoadSync,
+    [gfxd_DPTileSync]              = chk_DPTileSync,
+    [gfxd_DPPipeSync]              = chk_DPPipeSync,
+    [gfxd_DPLoadTLUT_pal16]        = NULL,
+    [gfxd_DPLoadTLUT_pal256]       = NULL,
+    [gfxd_DPLoadMultiBlockYuvS]    = NULL,
+    [gfxd_DPLoadMultiBlockYuv]     = NULL,
+    [gfxd_DPLoadMultiBlock_4bS]    = NULL,
+    [gfxd_DPLoadMultiBlock_4b]     = NULL,
+    [gfxd_DPLoadMultiBlockS]       = NULL,
+    [gfxd_DPLoadMultiBlock]        = NULL,
+    [gfxd__DPLoadTextureBlockYuvS] = NULL,
+    [gfxd__DPLoadTextureBlockYuv]  = NULL,
+    [gfxd__DPLoadTextureBlock_4bS] = NULL,
+    [gfxd__DPLoadTextureBlock_4b]  = NULL,
+    [gfxd__DPLoadTextureBlockS]    = NULL,
+    [gfxd__DPLoadTextureBlock]     = NULL,
+    [gfxd_DPLoadTextureBlockYuvS]  = NULL,
+    [gfxd_DPLoadTextureBlockYuv]   = NULL,
+    [gfxd_DPLoadTextureBlock_4bS]  = NULL,
+    [gfxd_DPLoadTextureBlock_4b]   = chk_DPLoadTextureBlock_4b,
+    [gfxd_DPLoadTextureBlockS]     = NULL,
+    [gfxd_DPLoadTextureBlock]      = chk_DPLoadTextureBlock,
+    [gfxd_DPLoadMultiTileYuv]      = NULL,
+    [gfxd_DPLoadMultiTile_4b]      = NULL,
+    [gfxd_DPLoadMultiTile]         = NULL,
+    [gfxd__DPLoadTextureTileYuv]   = NULL,
+    [gfxd__DPLoadTextureTile_4b]   = NULL,
+    [gfxd__DPLoadTextureTile]      = NULL,
+    [gfxd_DPLoadTextureTileYuv]    = NULL,
+    [gfxd_DPLoadTextureTile_4b]    = NULL,
+    [gfxd_DPLoadTextureTile]       = NULL,
+    [gfxd_DPLoadBlock]             = chk_DPLoadBlock,
+    [gfxd_DPNoOp]                  = NULL,
+    [gfxd_DPNoOpTag]               = NULL,
+    [gfxd_DPNoOpTag3]              = NULL,
+    [gfxd_DPPipelineMode]          = chk_DPPipelineMode,
+    [gfxd_DPSetBlendColor]         = chk_DPSetBlendColor,
+    [gfxd_DPSetEnvColor]           = chk_DPSetEnvColor,
+    [gfxd_DPSetFillColor]          = chk_DPSetFillColor,
+    [gfxd_DPSetFogColor]           = chk_DPSetFogColor,
+    [gfxd_DPSetPrimColor]          = chk_DPSetPrimColor,
+    [gfxd_DPSetColorImage]         = chk_DPSetColorImage,
+    [gfxd_DPSetDepthImage]         = chk_DPSetDepthImage,
+    [gfxd_DPSetTextureImage]       = chk_DPSetTextureImage,
+    [gfxd_DPSetAlphaCompare]       = chk_DPSetAlphaCompare,
+    [gfxd_DPSetAlphaDither]        = chk_DPSetAlphaDither,
+    [gfxd_DPSetColorDither]        = chk_DPSetColorDither,
+    [gfxd_DPSetCombineMode]        = chk_DPSetCombine,
+    [gfxd_DPSetCombineLERP]        = chk_DPSetCombine,
+    [gfxd_DPSetConvert]            = chk_DPSetConvert,
+    [gfxd_DPSetTextureConvert]     = chk_DPSetTextureConvert,
+    [gfxd_DPSetCycleType]          = chk_DPSetCycleType,
+    [gfxd_DPSetDepthSource]        = chk_DPSetDepthSource,
+    [gfxd_DPSetCombineKey]         = chk_DPSetCombineKey,
+    [gfxd_DPSetKeyGB]              = chk_DPSetKeyGB,
+    [gfxd_DPSetKeyR]               = chk_DPSetKeyR,
+    [gfxd_DPSetPrimDepth]          = chk_DPSetPrimDepth,
+    [gfxd_DPSetRenderMode]         = chk_DPSetRenderMode,
+    [gfxd_DPSetScissor]            = chk_DPSetScissor,
+    [gfxd_DPSetScissorFrac]        = chk_DPSetScissorFrac,
+    [gfxd_DPSetTextureDetail]      = chk_DPSetTextureDetail,
+    [gfxd_DPSetTextureFilter]      = chk_DPSetTextureFilter,
+    [gfxd_DPSetTextureLOD]         = chk_DPSetTextureLOD,
+    [gfxd_DPSetTextureLUT]         = chk_DPSetTextureLUT,
+    [gfxd_DPSetTexturePersp]       = chk_DPSetTexturePersp,
+    [gfxd_DPSetTile]               = chk_DPSetTile,
+    [gfxd_DPSetTileSize]           = chk_DPSetTileSize,
+    [gfxd_SP1Triangle]             = chk_SP1Triangle,
+    [gfxd_SP2Triangles]            = chk_SP2Triangles,
+    [gfxd_SP1Quadrangle]           = chk_SP1Quadrangle,
+    [gfxd_SPBranchLessZraw]        = chk_SPBranchLessZraw,
+    [gfxd_SPBranchList]            = chk_SPBranchList,
+    [gfxd_SPClipRatio]             = chk_SPClipRatio,
+    [gfxd_SPCullDisplayList]       = chk_SPCullDisplayList,
+    [gfxd_SPDisplayList]           = chk_SPDisplayList,
+    [gfxd_SPEndDisplayList]        = chk_SPEndDisplayList,
+    [gfxd_SPFogFactor]             = chk_SPFogFactor,
+    [gfxd_SPFogPosition]           = chk_SPFogPosition,
+    [gfxd_SPForceMatrix]           = chk_SPForceMatrix,
+    [gfxd_SPSetGeometryMode]       = chk_SPSetGeometryMode,
+    [gfxd_SPClearGeometryMode]     = chk_SPClearGeometryMode,
+    [gfxd_SPLoadGeometryMode]      = chk_SPLoadGeometryMode,
+    [gfxd_SPInsertMatrix]          = chk_SPInsertMatrix,
+    [gfxd_SPLine3D]                = chk_SPLine3D,
+    [gfxd_SPLineW3D]               = chk_SPLineW3D,
+    [gfxd_SPLoadUcode]             = chk_SPLoadUcode,
+    [gfxd_SPLookAtX]               = chk_SPLookAtX,
+    [gfxd_SPLookAtY]               = chk_SPLookAtY,
+    [gfxd_SPLookAt]                = chk_SPLookAt,
+    [gfxd_SPMatrix]                = chk_SPMatrix,
+    [gfxd_SPModifyVertex]          = chk_SPModifyVertex,
+    [gfxd_SPPerspNormalize]        = chk_SPPerspNormalize,
+    [gfxd_SPPopMatrix]             = chk_SPPopMatrix,
+    [gfxd_SPPopMatrixN]            = chk_SPPopMatrixN,
+    [gfxd_SPSegment]               = chk_SPSegment,
+    [gfxd_SPSetLights1]            = chk_SPSetLights1,
+    [gfxd_SPSetLights2]            = chk_SPSetLights2,
+    [gfxd_SPSetLights3]            = chk_SPSetLights3,
+    [gfxd_SPSetLights4]            = chk_SPSetLights4,
+    [gfxd_SPSetLights5]            = chk_SPSetLights5,
+    [gfxd_SPSetLights6]            = chk_SPSetLights6,
+    [gfxd_SPSetLights7]            = chk_SPSetLights7,
+    [gfxd_SPNumLights]             = chk_SPNumLights,
+    [gfxd_SPLight]                 = chk_SPLight,
+    [gfxd_SPLightColor]            = chk_SPLightColor,
+    [gfxd_SPTexture]               = chk_SPTexture,
+    [gfxd_SPTextureRectangle]      = chk_SPTextureRectangle,
+    [gfxd_SPTextureRectangleFlip]  = chk_SPTextureRectangleFlip,
+    [gfxd_SPVertex]                = chk_SPVertex,
+    [gfxd_SPViewport]              = chk_SPViewport,
+    [gfxd_DPLoadTLUTCmd]           = chk_DPLoadTLUTCmd,
+    [gfxd_DPLoadTLUT]              = NULL,
+    [gfxd_BranchZ]                 = chk_BranchZ,
+    [gfxd_DisplayList]             = chk_DisplayList,
+    [gfxd_DPHalf1]                 = chk_DPHalf1,
+    [gfxd_DPHalf2]                 = chk_DPHalf2,
+    [gfxd_DPWord]                  = chk_DPWord,
+    [gfxd_DPLoadTile]              = chk_DPLoadTile,
+    [gfxd_SPGeometryMode]          = chk_SPGeometryMode,
+    [gfxd_SPSetOtherMode]          = chk_SPSetOtherMode,
+    [gfxd_SPSetOtherModeLo]        = chk_SPSetOtherModeLo,
+    [gfxd_SPSetOtherModeHi]        = chk_SPSetOtherModeHi,
+    [gfxd_DPSetOtherMode]          = chk_DPSetOtherMode,
+    [gfxd_MoveWd]                  = chk_MoveWd,
+    [gfxd_MoveMem]                 = chk_MoveMem,
+    [gfxd_SPDma_io]                = chk_SPDma_io,
+    [gfxd_SPDmaRead]               = chk_SPDmaRead,
+    [gfxd_SPDmaWrite]              = chk_SPDmaWrite,
+    [gfxd_LoadUcode]               = chk_LoadUcode,
+    [gfxd_SPLoadUcodeEx]           = chk_SPLoadUcodeEx,
+    [gfxd_TexRect]                 = NULL,
+    [gfxd_TexRectFlip]             = NULL,
+    [gfxd_SPNoOp]                  = chk_SPNoOp,
+    [gfxd_Special3]                = chk_Special3,
+    [gfxd_Special2]                = chk_Special2,
+    [gfxd_Special1]                = chk_Special1,
+    [gfxd_SPBgRectCopy]            = chk_SPBgRectCopy,
+    [gfxd_SPBgRect1Cyc]            = chk_SPBgRect1Cyc,
+    [gfxd_SPObjRectangle]          = chk_SPObjRectangle,
+    [gfxd_SPObjRectangleR]         = chk_SPObjRectangleR,
+    [gfxd_SPObjSprite]             = chk_SPObjSprite,
+    [gfxd_SPObjMatrix]             = chk_SPObjMatrix,
+    [gfxd_SPObjSubMatrix]          = chk_SPObjSubMatrix,
+    [gfxd_ObjMoveMem]              = chk_ObjMoveMem,
+    [gfxd_SPObjRenderMode]         = chk_SPObjRenderMode,
+    [gfxd_SPObjLoadTxtr]           = chk_SPObjLoadTxtr,
+    [gfxd_SPObjLoadTxRect]         = chk_SPObjLoadTxRect,
+    [gfxd_SPObjLoadTxRectR]        = chk_SPObjLoadTxRectR,
+    [gfxd_SPObjLoadTxSprite]       = chk_SPObjLoadTxSprite,
+    [gfxd_SelectDL]                = chk_SelectDL,
+    [gfxd_SPSelectDL]              = chk_SPSelectDL,
+    [gfxd_SPSelectBranchDL]        = chk_SPSelectBranchDL,
+    [gfxd_DPHalf0]                 = chk_DPHalf0,
+    [gfxd_SPSetStatus]             = chk_SPSetStatus,
 };
 
 #define STRING_COLOR VT_RGB256COL(130) //VT_SGR("0;92") // green
 
-#define ZDZ_UNPACK_Z(x)     (((x) >> 2) & 0x3FFF)
-#define ZDZ_UNPACK_DZ(x)    (((x) >> 0) & 3)
+#define ZDZ_UNPACK_Z(x)  (((x) >> 2) & 0x3FFF)
+#define ZDZ_UNPACK_DZ(x) (((x) >> 0) & 3)
 
 #define RGBA16_R(x) (((x) >> 11) & 0x1F)
-#define RGBA16_G(x) (((x) >>  6) & 0x1F)
-#define RGBA16_B(x) (((x) >>  1) & 0x1F)
-#define RGBA16_A(x) (((x) >>  0) & 1)
+#define RGBA16_G(x) (((x) >> 6) & 0x1F)
+#define RGBA16_B(x) (((x) >> 1) & 0x1F)
+#define RGBA16_A(x) (((x) >> 0) & 1)
 
-#define RGBA16_EXPAND(x)    (((x) << 3) | ((x) >> 2))
+#define RGBA16_EXPAND(x) (((x) << 3) | ((x) >> 2))
 
 static void
-arg_handler (int arg_num)
-{
+arg_handler(int arg_num) {
     // No checking is done here, it is left entirely to command handlers
-    int m_id = gfxd_macro_id();
-    int arg_type = gfxd_arg_type(arg_num);
+    int m_id           = gfxd_macro_id();
+    int arg_type       = gfxd_arg_type(arg_num);
     gfx_state_t *state = (gfx_state_t *)gfxd_udata_get();
 
     if (gfxd_arg_callbacks(arg_num) != 0)
@@ -3989,8 +3784,7 @@ arg_handler (int arg_num)
 
     const gfxd_value_t *arg_value;
 
-    switch (arg_type)
-    {
+    switch (arg_type) {
         case gfxd_Tlut:
         case gfxd_Timg:
         case gfxd_Cimg:
@@ -4020,24 +3814,21 @@ arg_handler (int arg_num)
                 gfxd_printf(" /* 0x%08X */", ram_addr);
             break;
         case gfxd_Color:
-            if (m_id == gfxd_DPSetFillColor && state->cimg_set)
-            {
+            if (m_id == gfxd_DPSetFillColor && state->cimg_set) {
                 const char *color_fmt = (state->options->hex_color)
-                                      ? "0x%02X, 0x%02X, 0x%02X, 0x%02X"
-                                      : "%d, %d, %d, %d";
-                uint32_t color = gfxd_arg_value(arg_num)->u;
+                                            ? "0x%02X, 0x%02X, 0x%02X, 0x%02X"
+                                            : "%d, %d, %d, %d";
+                uint32_t color        = gfxd_arg_value(arg_num)->u;
 
                 // TODO decimal vs hexadecimal colors
-                switch (FMT_SIZ(state->last_cimg.fmt, state->last_cimg.siz))
-                {
+                switch (FMT_SIZ(state->last_cimg.fmt, state->last_cimg.siz)) {
                     case FMT_SIZ(G_IM_FMT_RGBA, G_IM_SIZ_16b):
                         if (state->zimg_set && state->last_cimg.addr == state->last_zimg.addr)
                             // color and depth images match, write as zdz
                             gfxd_printf("(GPACK_ZDZ(0x%X, 0x%X) << 16) | GPACK_ZDZ(0x%X, 0x%X)",
                                         ZDZ_UNPACK_Z(color >> 16), ZDZ_UNPACK_DZ(color >> 16),
-                                        ZDZ_UNPACK_Z(color >>  0), ZDZ_UNPACK_DZ(color >>  0));
-                        else
-                        {
+                                        ZDZ_UNPACK_Z(color >> 0), ZDZ_UNPACK_DZ(color >> 0));
+                        else {
                             // otherwise write as rgba16
                             gfxd_puts("(GPACK_RGBA5551(");
                             gfxd_printf(color_fmt,
@@ -4045,8 +3836,8 @@ arg_handler (int arg_num)
                                         RGBA16_EXPAND(RGBA16_B(color >> 16)), 255 * RGBA16_A(color >> 16));
                             gfxd_puts(") << 16) | GPACK_RGBA5551(");
                             gfxd_printf(color_fmt,
-                                        RGBA16_EXPAND(RGBA16_R(color >>  0)), RGBA16_EXPAND(RGBA16_G(color >>  0)),
-                                        RGBA16_EXPAND(RGBA16_B(color >>  0)), 255 * RGBA16_A(color >>  0));
+                                        RGBA16_EXPAND(RGBA16_R(color >> 0)), RGBA16_EXPAND(RGBA16_G(color >> 0)),
+                                        RGBA16_EXPAND(RGBA16_B(color >> 0)), 255 * RGBA16_A(color >> 0));
                             gfxd_puts(")");
                         }
                         break;
@@ -4055,13 +3846,12 @@ arg_handler (int arg_num)
                     case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_8b):
                         if (state->options->hex_color)
                             gfxd_printf("%08X", color);
-                        else
-                        {
+                        else {
                             // this macro isn't really part of the sdk.. but better than %08X ?
                             gfxd_puts("GPACK_RGBA8888(");
                             gfxd_printf(color_fmt,
                                         (color >> 24) & 0xFF, (color >> 16) & 0xFF,
-                                        (color >>  8) & 0xFF, (color >>  0) & 0xFF);
+                                        (color >> 8) & 0xFF, (color >> 0) & 0xFF);
                             gfxd_puts(")");
                         }
                         break;
@@ -4076,14 +3866,12 @@ arg_handler (int arg_num)
 }
 
 static void
-decode_noop_cmd (gfx_state_t *state)
-{
-    const gfxd_value_t *noop_type = gfxd_arg_value(0 /* type */);
-    const gfxd_value_t *noop_data = gfxd_arg_value(1 /* data */);
+decode_noop_cmd(gfx_state_t *state) {
+    const gfxd_value_t *noop_type  = gfxd_arg_value(0 /* type */);
+    const gfxd_value_t *noop_data  = gfxd_arg_value(1 /* data */);
     const gfxd_value_t *noop_data1 = gfxd_arg_value(2 /* data1 */);
 
-    switch (noop_type->u)
-    {
+    switch (noop_type->u) {
         // TODO these break dynamic macros
         case 1:
             gfxd_printf("gsDPNoOpHere(" STRING_COLOR);
@@ -4093,7 +3881,7 @@ decode_noop_cmd (gfx_state_t *state)
         case 2:
             gfxd_printf("gsDPNoOpString(" STRING_COLOR);
             print_string(state, segmented_to_physical(state, noop_data->u), gfx_fprintf_wrapper, NULL);
-            gfxd_printf(VT_RST ", 0x%04X)",  noop_data1->u);
+            gfxd_printf(VT_RST ", 0x%04X)", noop_data1->u);
             break;
         case 3:
             gfxd_printf("gsDPNoOpWord(0x%08X, 0x%04X)", noop_data->u, noop_data1->u);
@@ -4116,23 +3904,23 @@ decode_noop_cmd (gfx_state_t *state)
         case 7:
             gfxd_printf(VT_FGCOL(GREEN) "gsDPNoOpOpenDisp" VT_RST "(" STRING_COLOR);
             print_string(state, segmented_to_physical(state, noop_data->u), gfx_fprintf_wrapper, NULL);
-            gfxd_printf(VT_RST ", %d)",  noop_data1->u);
+            gfxd_printf(VT_RST ", %d)", noop_data1->u);
 
             DispEntry open_ent = {
                 .str_addr = segmented_to_physical(state, noop_data->u),
-                .line_no = noop_data1->u,
+                .line_no  = noop_data1->u,
             };
             obstack_push(&state->disp_stack, &open_ent);
             break;
         case 8:
             gfxd_printf(VT_FGCOL(RED) "gsDPNoOpCloseDisp" VT_RST "(" STRING_COLOR);
             print_string(state, segmented_to_physical(state, noop_data->u), gfx_fprintf_wrapper, NULL);
-            gfxd_printf(VT_RST ", %d)",  noop_data1->u);
+            gfxd_printf(VT_RST ", %d)", noop_data1->u);
 
             obstack_pop(&state->disp_stack, 1);
             break;
         default:
-emit_noop_tag3:
+        emit_noop_tag3:
             gfxd_printf("%s(0x%02X, 0x%08X, 0x%04X)", gfxd_macro_name(), noop_type->u, noop_data->u, noop_data1->u);
             WARNING_ERROR(state, GW_UNK_NOOP_TAG3);
             break;
@@ -4140,28 +3928,21 @@ emit_noop_tag3:
 }
 
 static void
-macro_print (void)
-{
-    unsigned int m_id = gfxd_macro_id();
+macro_print(void) {
+    unsigned int m_id  = gfxd_macro_id();
     gfx_state_t *state = (gfx_state_t *)gfxd_udata_get();
 
-    if (m_id == gfxd_DPNoOpTag3)
-    {
+    if (m_id == gfxd_DPNoOpTag3) {
         /* decode special NoOps */
         decode_noop_cmd(state);
-    }
-    else
-    {
+    } else {
         const char *name = gfxd_macro_name();
-        if (name == NULL)
-        {
+        if (name == NULL) {
             gfxd_puts("(Gfx){");
-        }
-        else
-        {
+        } else {
             static const char *macro_colors[] =
                 {
-                    [gfxd_SPDisplayList] = VT_FGCOL(CYAN),
+                    [gfxd_SPDisplayList]    = VT_FGCOL(CYAN),
                     [gfxd_SPEndDisplayList] = VT_FGCOL(PURPLE),
                 };
 
@@ -4177,8 +3958,7 @@ macro_print (void)
         }
 
         int n_arg = gfxd_arg_count();
-        for (int i = 0; i < n_arg; i++)
-        {
+        for (int i = 0; i < n_arg; i++) {
             if (i != 0)
                 gfxd_puts(", ");
 
@@ -4190,13 +3970,11 @@ macro_print (void)
 }
 
 static int
-do_single_gfx (void)
-{
-    int m_id = gfxd_macro_id();
+do_single_gfx(void) {
+    int m_id           = gfxd_macro_id();
     gfx_state_t *state = (gfx_state_t *)gfxd_udata_get();
 
-    if (state->multi_packet && state->options->print_multi_packet)
-    {
+    if (state->multi_packet && state->options->print_multi_packet) {
         gfxd_puts("            ");
         macro_print();
         gfxd_puts(",\n");
@@ -4208,14 +3986,11 @@ do_single_gfx (void)
 
     // Tile busy
 
-    for (int i = 0; i < 8; i++)
-    {
-        if (state->tile_busy[i] > 0)
-        {
+    for (int i = 0; i < 8; i++) {
+        if (state->tile_busy[i] > 0) {
             // If tile is marked busy by a command, increment busy counter
             state->tile_busy[i]++;
-            if (state->tile_busy[i] >= 2)
-            {
+            if (state->tile_busy[i] >= 2) {
                 // Been busy for long enough, release the tile.
                 // Supposedly tiles are not busy for long
                 state->tile_busy[i] = 0;
@@ -4227,9 +4002,8 @@ do_single_gfx (void)
 }
 
 static int
-macro_fn (void)
-{
-    int m_id = gfxd_macro_id();
+macro_fn(void) {
+    int m_id           = gfxd_macro_id();
     gfx_state_t *state = (gfx_state_t *)gfxd_udata_get();
 
     gfxd_printf("  /* %6d %08X */  ", state->n_gfx, state->gfx_addr);
@@ -4249,12 +4023,12 @@ macro_fn (void)
             fn(state);
 
         // multi-packet handling
-        strncpy(state->multi_packet_name, gfxd_macro_name(), sizeof(state->multi_packet_name)-1);
+        strncpy(state->multi_packet_name, gfxd_macro_name(), sizeof(state->multi_packet_name) - 1);
         state->multi_packet = true;
         if (m_id != gfxd_SPTextureRectangle && m_id != gfxd_SPTextureRectangleFlip)
             // gfxd_printf("In expansion of %s:\n", gfxd_macro_name());
             gfxd_foreach_pkt(do_single_gfx);
-            // gfxd_puts("[done]\n");
+        // gfxd_puts("[done]\n");
 
         state->multi_packet = false;
     }
@@ -4268,15 +4042,13 @@ macro_fn (void)
  */
 
 static int
-empty_output_callback (const char *buf, int count)
-{
+empty_output_callback(const char *buf, int count) {
     /* Drop the printed string */
     return count;
 }
 
 static int
-input_callback (void *buf, int count)
-{
+input_callback(void *buf, int count) {
     gfx_state_t *state = gfxd_udata_get();
 
     state->rdram->seek(state->gfx_addr);
@@ -4287,65 +4059,59 @@ input_callback (void *buf, int count)
  *  Main
  */
 
-int
-analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts, rdram_interface_t *rdram,
-             const void *rdram_arg, uint32_t start_addr, uint32_t auto_start_ptr_addr)
-{
+int analyze_gbi(FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts, rdram_interface_t *rdram,
+                const void *rdram_arg, uint32_t start_addr, uint32_t auto_start_ptr_addr) {
     gfx_state_t state = {
-        .task_done = false,
+        .task_done        = false,
         .pipeline_crashed = false,
-        .multi_packet = false,
+        .multi_packet     = false,
 
         .last_gfx_pkt_count = 1,
 
-        .segment_set_bits = 1,
-        .matrix_stack_depth = 0,
+        .segment_set_bits      = 1,
+        .matrix_stack_depth    = 0,
         .matrix_projection_set = false,
-        .matrix_modelview_set = false,
+        .matrix_modelview_set  = false,
 
         .sp_dram_stack_size = 0x400, // TODO this is configurable
 
-        .render_tile = G_TX_RENDERTILE,
-        .render_tile_on = false,
+        .render_tile         = G_TX_RENDERTILE,
+        .render_tile_on      = false,
         .last_loaded_vtx_num = 0,
-        .persp_norm = 1.0,
-        .geometry_mode = G_CLIPPING,
-        .dl_stack_top = -1,
-        .scissor_set = false,
-        .othermode_hi = 0,
-        .othermode_lo = 0,
-        .combiner_hi = 0,
-        .combiner_lo = 0,
-        .pipe_busy = false,
-        .tile_busy = { 0 },
-        .load_busy = false,
-        .fill_color = 0,
-        .fill_color_set = false,
+        .persp_norm          = 1.0,
+        .geometry_mode       = G_CLIPPING,
+        .dl_stack_top        = -1,
+        .scissor_set         = false,
+        .othermode_hi        = 0,
+        .othermode_lo        = 0,
+        .combiner_hi         = 0,
+        .combiner_lo         = 0,
+        .pipe_busy           = false,
+        .tile_busy           = {0},
+        .load_busy           = false,
+        .fill_color          = 0,
+        .fill_color_set      = false,
     };
 
-    state.ucodes = ucodes;
-    state.rdram = rdram;
+    state.ucodes  = ucodes;
+    state.rdram   = rdram;
     state.options = opts;
 
-    if (state.rdram->open(rdram_arg))
-    {
+    if (state.rdram->open(rdram_arg)) {
         fprintf(print_out, ERROR_COLOR "FAILED to open RDRAM image\n");
         goto err;
     }
 
-    if (start_addr == 0xFFFFFFFF)
-    {
+    if (start_addr == 0xFFFFFFFF) {
         uint32_t auto_start_addr;
-        if (!state.rdram->read_at(&auto_start_addr, auto_start_ptr_addr & ~KSEG_MASK, sizeof(uint32_t)))
-        {
+        if (!state.rdram->read_at(&auto_start_addr, auto_start_ptr_addr & ~KSEG_MASK, sizeof(uint32_t))) {
             fprintf(print_out, ERROR_COLOR "FAILED to read auto start pointer\n");
             goto err;
         }
         start_addr = BSWAP32(auto_start_addr);
     }
     start_addr &= ~KSEG_MASK;
-    if (!state.rdram->seek(start_addr))
-    {
+    if (!state.rdram->seek(start_addr)) {
         fprintf(print_out, ERROR_COLOR "FAILED to seek to start address\n");
         goto err;
     }
@@ -4353,7 +4119,7 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
 
     obstack_new(&state.disp_stack, sizeof(DispEntry));
     obstack_new(&state.mtx_stack, sizeof(MtxF));
-    MtxF zero_mf = { 0 };
+    MtxF zero_mf = {0};
     obstack_push(&state.mtx_stack, &zero_mf);
 
     gfxd_input_callback(input_callback);
@@ -4384,25 +4150,20 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
     gfxd_target(gfxd_f3dex2);
 
     state.n_gfx = 0;
-    while (!state.task_done /* && !state.pipeline_crashed */ && gfxd_execute() == 1)
-    {
+    while (!state.task_done /* && !state.pipeline_crashed */ && gfxd_execute() == 1) {
         state.n_gfx++;
         state.gfx_addr += state.last_gfx_pkt_count * sizeof(Gfx);
         gfxd_target(state.next_ucode);
 
-        if (state.options->line != 0 && state.n_gfx == state.options->line)
-        {
+        if (state.options->line != 0 && state.n_gfx == state.options->line) {
             state.task_done = true;
             break;
         }
     }
 
-    if (state.task_done)
-    {
+    if (state.task_done) {
         fprintf(print_out, "Graphics task completed successfully.\n");
-    }
-    else
-    {
+    } else {
         fprintf(print_out, "\n        " ERROR_COLOR "Graphics Task has CRASHED" VT_RST "\n\n");
 
         // Print state information
@@ -4412,11 +4173,9 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
         fprintf(print_out, "In Display List ");
         if (cur_dl == 0)
             fprintf(print_out, "ROOT\n");
-        else
-        {
+        else {
             fprintf(print_out, "0x%08X (command #%d)\n", cur_dl, state.n_gfx - 1);
-            if (state.dl_stack_top > 0)
-            {
+            if (state.dl_stack_top > 0) {
                 // print a display list stack trace if more than 1 dl deep
                 fprintf(print_out, "Stack Trace:\n");
                 for (int i = state.dl_stack_top; i > 0; i--)
@@ -4425,8 +4184,7 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
         }
 
         fprintf(print_out, "DISP refs trace:\n");
-        VECTOR_FOR_EACH_ELEMENT_REVERSED(&state.disp_stack.v, ent, DispEntry*)
-        {
+        VECTOR_FOR_EACH_ELEMENT_REVERSED(&state.disp_stack.v, ent, DispEntry *) {
             fprintf(print_out, "    At ");
             print_string(&state, ent->str_addr, fprintf, print_out);
             fprintf(print_out, ", %d\n", ent->line_no);
@@ -4434,7 +4192,6 @@ analyze_gbi (FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts,
 
         fprintf(print_out, "Segment dump:\n");
         print_segments(print_out, state.segment_table);
-
     }
 
     // TODO output more information here


### PR DESCRIPTION
I wrote the .clang-format such that it changes the least the existing style, besides K&R braces style

The following should probably change eventually though:
```yaml
ColumnLimit: 0
ReflowComments: false
```
(to
```yaml
ColumnLimit: 80
ReflowComments: true
```
)