### PR TITLE
Fix --print-textures CI

### DIFF
--- a/src/gbd/main.c
+++ b/src/gbd/main.c
@@ -24,6 +24,7 @@ usage(char *exec_name)
            "[--print-vertices] "
            "[--print-matrices] "
            "[--print-lights] "
+           "[--print-multi-packet] "
            "[--to-num <n>] "
            "[--encoding <encoding>] "
            "[--quiet] "

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -2270,9 +2270,9 @@ chk_SPViewport(gfx_state_t *state)
     state->cur_vp.vp.vtrans[2] = BSWAP16(state->cur_vp.vp.vtrans[2]);
 
     gfxd_printf("        VIEWPORT(\n"
-                "            .vscale.x = qs142(%8.2f), .vtrans.x = qs142(%8.2f)\n"
-                "            .vscale.y = qs142(%8.2f), .vtrans.y = qs142(%8.2f)\n"
-                "            .vscale.z = qs142(%8.2f), .vtrans.z = qs142(%8.2f)\n"
+                "            .vscale.x = qs142(%8.2f), .vtrans.x = qs142(%8.2f),\n"
+                "            .vscale.y = qs142(%8.2f), .vtrans.y = qs142(%8.2f),\n"
+                "            .vscale.z = qs142(%8.2f), .vtrans.z = qs142(%8.2f),\n"
                 "        );\n",
                 state->cur_vp.vp.vscale[0] / 4.0f, state->cur_vp.vp.vtrans[0] / 4.0f, state->cur_vp.vp.vscale[1] / 4.0f,
                 state->cur_vp.vp.vtrans[1] / 4.0f, state->cur_vp.vp.vscale[2] / 4.0f,

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -1300,7 +1300,7 @@ print_othermode(FILE *print_out, uint32_t othermode_hi, uint32_t othermode_lo)
     print_othermode_lo(print_out, othermode_lo);
 }
 
-#define PRINT_PX(r, g, b) printf(VT_RGBCOL_S("%d;%d;%d", "%d;%d;%d") "\u2584\u2584", r, g, b, r, g, b)
+#define PRINT_PX(r, g, b) gfxd_printf(VT_RGBCOL_S("%d;%d;%d", "%d;%d;%d") "\u2584\u2584", r, g, b, r, g, b)
 
 #define CVT_PX(c, sft, mask) ((((c) >> (sft)) & (mask)) * (255 / (mask)))
 
@@ -1484,20 +1484,20 @@ draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, 
                     goto bad_fmt_siz_err;
             }
         }
-        printf(VT_RST "\n");
+        gfxd_printf(VT_RST "\n");
     }
     return 0;
 
 no_preview:
-    printf(VT_RGBCOL(255, 110, 0, 255, 255, 255) "CI texture could not be previewed" VT_RST "\n");
+    gfxd_printf(VT_RGBCOL(255, 110, 0, 255, 255, 255) "CI texture could not be previewed" VT_RST "\n");
     return 1;
 
 read_err:
-    printf(VT_RGBCOL(255, 0, 0, 255, 255, 255) "READ ERROR" VT_RST "\n");
-    printf("%08lX\n", state->rdram->pos());
+    gfxd_printf(VT_RGBCOL(255, 0, 0, 255, 255, 255) "draw_last_timg READ ERROR" VT_RST "\n");
+    gfxd_printf("%08lX\n", state->rdram->pos());
     return -1;
 bad_fmt_siz_err:
-    printf(VT_RST);
+    gfxd_printf(VT_RST);
     return -2;
 }
 

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -3120,7 +3120,7 @@ chk_DPLoadTLUTCmd(gfx_state_t *state)
         tile_desc->lrt = lrt;
     }
 
-    if (state->last_ltb.n_gfx >= state->last_draw_n_gfx) {
+    if (state->options->print_textures && state->last_ltb.n_gfx >= state->last_draw_n_gfx) {
         draw_last_timg(state, state->last_ltb.addr_phys, state->last_ltb.fmt, state->last_ltb.siz,
                        state->last_ltb.height, state->last_ltb.width, state->last_ltb.pal);
     }

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -4173,6 +4173,14 @@ chk_LTB(gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int heig
 {
     // ARG_CHECK(state, ltb_dims_valid(width, height, siz), "Bad width-height combination for LoadTextureBlock");
 
+    state->last_ltb.n_gfx     = state->n_gfx;
+    state->last_ltb.addr_phys = segmented_to_physical(state, timg);
+    state->last_ltb.fmt       = fmt;
+    state->last_ltb.siz       = siz;
+    state->last_ltb.width     = width;
+    state->last_ltb.height    = height;
+    state->last_ltb.pal       = pal;
+
     int mlines = max_lines(width, siz);
 
     // For LTB, not all width-height combinations are valid for loading. Check that the load is not corrupted.
@@ -4214,14 +4222,6 @@ chk_DPLoadTextureBlock(gfx_state_t *state)
     int      maskt  = gfxd_arg_value(9)->i;
     int      shifts = gfxd_arg_value(10)->i;
     int      shiftt = gfxd_arg_value(11)->i;
-
-    state->last_ltb.n_gfx     = state->n_gfx;
-    state->last_ltb.addr_phys = segmented_to_physical(state, timg);
-    state->last_ltb.fmt       = fmt;
-    state->last_ltb.siz       = siz;
-    state->last_ltb.width     = width;
-    state->last_ltb.height    = height;
-    state->last_ltb.pal       = pal;
 
     return chk_LTB(state, timg, fmt, siz, width, height, pal, cms, cmt, masks, maskt, shifts, shiftt);
 }

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -4146,8 +4146,10 @@ chk_LTB(gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int heig
 
     if (state->options->print_textures) {
         tile_descriptor_t *tile_desc = get_tile_desc(state, pal);
-        if (tile_desc != NULL)
-            draw_last_timg(state, timg, fmt, siz, height, width, tile_desc->tmem, pal, tile_desc->lrs);
+        if (tile_desc != NULL) {
+            uint32_t timg_phys = segmented_to_physical(state, timg);
+            draw_last_timg(state, timg_phys, fmt, siz, height, width, tile_desc->tmem, pal, tile_desc->lrs);
+        }
     }
 
     return 0;

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -141,6 +141,11 @@ typedef struct {
 #define VTX_CACHE_SIZE 32
 
 typedef struct {
+    int      n_gfx; // Position in state.n_gfx units
+    uint32_t addr_phys;
+} last_load_tlut_t;
+
+typedef struct {
     // Options
     gbd_options_t        *options;
     gfx_ucode_registry_t *ucodes;
@@ -229,8 +234,16 @@ typedef struct {
         uint32_t width;
         uint32_t addr;
     } last_timg;
-    uint32_t fill_color;
-    bool     fill_color_set;
+    uint32_t         fill_color;
+    bool             fill_color_set;
+    int              last_draw_n_gfx;
+    last_load_tlut_t last_load_tlut_pal16[16];
+    last_load_tlut_t last_load_tlut_pal256;
+    struct {
+        int      n_gfx;
+        uint32_t addr_phys;
+        int      fmt, siz, width, height, pal;
+    } last_ltb;
 
     // RDRAM
     rdram_interface_t *rdram;
@@ -1305,10 +1318,10 @@ print_othermode(FILE *print_out, uint32_t othermode_hi, uint32_t othermode_lo)
 #define CVT_PX(c, sft, mask) ((((c) >> (sft)) & (mask)) * (255 / (mask)))
 
 int
-draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, int width, uint32_t tlut, int tlut_type,
-               int tlut_count)
+draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, int width, int pal)
 {
-    int fmt_siz = FMT_SIZ(fmt, siz);
+    int      fmt_siz   = FMT_SIZ(fmt, siz);
+    uint32_t tlut_type = state->othermode_hi & MDMASK(TEXTLUT);
 
     state->rdram->seek(timg);
 
@@ -1346,13 +1359,15 @@ draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, 
                     {
                         // TODO previewing of CI4/CI8 textures is unreliable as the TLUT may be loaded after the index
                         // data
-                        if (tlut == 0 || tlut_type == G_TT_NONE)
+                        if (tlut_type == G_TT_NONE || state->last_load_tlut_pal16[pal].n_gfx <= state->last_draw_n_gfx)
                             goto no_preview;
 
                         uint8_t ci8_i_x2;
 
                         if (state->rdram->read(&ci8_i_x2, sizeof(uint8_t), 1) != 1)
                             goto read_err;
+
+                        uint32_t tlut = state->last_load_tlut_pal16[pal].addr_phys;
 
                         uint16_t tlut_pxs[2];
 
@@ -1378,6 +1393,8 @@ draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, 
                                     break;
                             }
                         }
+
+                        j++;
                     }
                     break;
 
@@ -1405,8 +1422,9 @@ draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, 
 
                 case FMT_SIZ(G_IM_FMT_CI, G_IM_SIZ_8b):
                     {
-                        if (tlut == 0 || tlut_type == G_TT_NONE)
+                        if (tlut_type == G_TT_NONE || state->last_load_tlut_pal256.n_gfx <= state->last_draw_n_gfx) {
                             goto no_preview;
+                        }
 
                         uint8_t ci8_i;
 
@@ -1415,6 +1433,8 @@ draw_last_timg(gfx_state_t *state, uint32_t timg, int fmt, int siz, int height, 
 
                         // if (ci8_i > tlut_count)
                         //     goto read_err;
+
+                        uint32_t tlut = state->last_load_tlut_pal256.addr_phys;
 
                         uint16_t tlut_px;
 
@@ -2539,6 +2559,8 @@ chk_render_primitive(gfx_state_t *state, enum prim_type prim_type, int tile)
 static int
 chk_DPFillTriangle(gfx_state_t *state, int tnum, int v0, int v1, int v2, int flag)
 {
+    state->last_draw_n_gfx = state->n_gfx;
+
     int last_loaded_vtx_num = state->last_loaded_vtx_num;
 
     bool all_in_bounds =
@@ -3026,6 +3048,25 @@ chk_DPLoadTile(gfx_state_t *state)
 }
 
 static int
+chk_DPLoadTLUT_pal16(gfx_state_t *state)
+{
+    uint32_t pal  = gfxd_arg_value(0)->u;
+    uint32_t dram = gfxd_arg_value(1)->u;
+    state->last_load_tlut_pal16[pal].n_gfx     = state->n_gfx;
+    state->last_load_tlut_pal16[pal].addr_phys = segmented_to_physical(state, dram);
+    return 0;
+}
+
+static int
+chk_DPLoadTLUT_pal256(gfx_state_t *state)
+{
+    uint32_t dram = gfxd_arg_value(0)->u;
+    state->last_load_tlut_pal256.n_gfx     = state->n_gfx;
+    state->last_load_tlut_pal256.addr_phys = segmented_to_physical(state, dram);
+    return 0;
+}
+
+static int
 chk_DPLoadTLUTCmd(gfx_state_t *state)
 {
     uint32_t *ltlut_data = (uint32_t *)gfxd_macro_data();
@@ -3078,6 +3119,12 @@ chk_DPLoadTLUTCmd(gfx_state_t *state)
         tile_desc->lrs = lrs;
         tile_desc->lrt = lrt;
     }
+
+    if (state->last_ltb.n_gfx >= state->last_draw_n_gfx) {
+        draw_last_timg(state, state->last_ltb.addr_phys, state->last_ltb.fmt, state->last_ltb.siz,
+                       state->last_ltb.height, state->last_ltb.width, state->last_ltb.pal);
+    }
+
     return 0;
 }
 
@@ -4145,11 +4192,8 @@ chk_LTB(gfx_state_t *state, uint32_t timg, int fmt, int siz, int width, int heig
     //           "a width of %d may only have at most %d texture lines, this has %d", width, mlines, height);
 
     if (state->options->print_textures) {
-        tile_descriptor_t *tile_desc = get_tile_desc(state, pal);
-        if (tile_desc != NULL) {
-            uint32_t timg_phys = segmented_to_physical(state, timg);
-            draw_last_timg(state, timg_phys, fmt, siz, height, width, tile_desc->tmem, pal, tile_desc->lrs);
-        }
+        uint32_t timg_phys = segmented_to_physical(state, timg);
+        draw_last_timg(state, timg_phys, fmt, siz, height, width, pal);
     }
 
     return 0;
@@ -4170,6 +4214,14 @@ chk_DPLoadTextureBlock(gfx_state_t *state)
     int      maskt  = gfxd_arg_value(9)->i;
     int      shifts = gfxd_arg_value(10)->i;
     int      shiftt = gfxd_arg_value(11)->i;
+
+    state->last_ltb.n_gfx     = state->n_gfx;
+    state->last_ltb.addr_phys = segmented_to_physical(state, timg);
+    state->last_ltb.fmt       = fmt;
+    state->last_ltb.siz       = siz;
+    state->last_ltb.width     = width;
+    state->last_ltb.height    = height;
+    state->last_ltb.pal       = pal;
 
     return chk_LTB(state, timg, fmt, siz, width, height, pal, cms, cmt, masks, maskt, shifts, shiftt);
 }
@@ -4211,8 +4263,8 @@ static chk_fn chk_tbl[] = {
     [gfxd_DPLoadSync]              = chk_DPLoadSync,
     [gfxd_DPTileSync]              = chk_DPTileSync,
     [gfxd_DPPipeSync]              = chk_DPPipeSync,
-    [gfxd_DPLoadTLUT_pal16]        = NULL,
-    [gfxd_DPLoadTLUT_pal256]       = NULL,
+    [gfxd_DPLoadTLUT_pal16]        = chk_DPLoadTLUT_pal16,
+    [gfxd_DPLoadTLUT_pal256]       = chk_DPLoadTLUT_pal256,
     [gfxd_DPLoadMultiBlockYuvS]    = NULL,
     [gfxd_DPLoadMultiBlockYuv]     = NULL,
     [gfxd_DPLoadMultiBlock_4bS]    = NULL,
@@ -4734,7 +4786,14 @@ analyze_gbi(FILE *print_out, gfx_ucode_registry_t *ucodes, gbd_options_t *opts, 
         .load_busy           = false,
         .fill_color          = 0,
         .fill_color_set      = false,
+
+        .last_draw_n_gfx       = -1,
+        .last_load_tlut_pal256 = { .n_gfx = -1 },
+        .last_ltb              = { .n_gfx = -1 },
     };
+
+    for (int i = 0; i < 16; i++)
+        state.last_load_tlut_pal16[i].n_gfx = -1;
 
     state.ucodes  = ucodes;
     state.rdram   = rdram;

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -3050,8 +3050,8 @@ chk_DPLoadTile(gfx_state_t *state)
 static int
 chk_DPLoadTLUT_pal16(gfx_state_t *state)
 {
-    uint32_t pal  = gfxd_arg_value(0)->u;
-    uint32_t dram = gfxd_arg_value(1)->u;
+    uint32_t pal                               = gfxd_arg_value(0)->u;
+    uint32_t dram                              = gfxd_arg_value(1)->u;
     state->last_load_tlut_pal16[pal].n_gfx     = state->n_gfx;
     state->last_load_tlut_pal16[pal].addr_phys = segmented_to_physical(state, dram);
     return 0;
@@ -3060,7 +3060,7 @@ chk_DPLoadTLUT_pal16(gfx_state_t *state)
 static int
 chk_DPLoadTLUT_pal256(gfx_state_t *state)
 {
-    uint32_t dram = gfxd_arg_value(0)->u;
+    uint32_t dram                          = gfxd_arg_value(0)->u;
     state->last_load_tlut_pal256.n_gfx     = state->n_gfx;
     state->last_load_tlut_pal256.addr_phys = segmented_to_physical(state, dram);
     return 0;

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -4541,16 +4541,19 @@ decode_noop_cmd(gfx_state_t *state)
 
             {
                 DispEntry *disp_ent = (DispEntry *)obstack_peek(&state->disp_stack);
-                if (disp_ent->dl_stack_top != state->dl_stack_top)
+                if (disp_ent->dl_stack_top != state->dl_stack_top) {
+                    gfxd_printf("\n");
                     WARNING_ERROR(state, GW_UNMATCHED_DISP);
-                else
+                } else {
                     obstack_pop(&state->disp_stack, 1);
+                }
             }
             break;
 
         default:
         emit_noop_tag3:
             gfxd_printf("%s(0x%02X, 0x%08X, 0x%04X)", gfxd_macro_name(), noop_type->u, noop_data->u, noop_data1->u);
+            gfxd_printf("\n");
             WARNING_ERROR(state, GW_UNK_NOOP_TAG3);
             break;
     }

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -1513,7 +1513,7 @@ no_preview:
     return 1;
 
 read_err:
-    gfxd_printf(VT_RGBCOL(255, 0, 0, 255, 255, 255) "draw_last_timg READ ERROR" VT_RST "\n");
+    gfxd_printf(VT_RGBCOL(255, 0, 0, 255, 255, 255) "READ ERROR" VT_RST "\n");
     gfxd_printf("%08lX\n", state->rdram->pos());
     return -1;
 bad_fmt_siz_err:

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -4541,7 +4541,7 @@ decode_noop_cmd(gfx_state_t *state)
 
             {
                 DispEntry *disp_ent = (DispEntry *)obstack_peek(&state->disp_stack);
-                if (disp_ent->dl_stack_top != state->dl_stack_top) {
+                if (disp_ent == NULL || disp_ent->dl_stack_top != state->dl_stack_top) {
                     gfxd_printf("\n");
                     WARNING_ERROR(state, GW_UNMATCHED_DISP);
                 } else {

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -4487,7 +4487,7 @@ decode_noop_cmd(gfx_state_t *state)
         case 1:
             gfxd_printf("gsDPNoOpHere(" STRING_COLOR);
             print_string(state, segmented_to_physical(state, noop_data->u), gfx_fprintf_wrapper, NULL);
-            gfxd_printf(VT_RST ", 0x%04X)", noop_data->u, noop_data1->u);
+            gfxd_printf(VT_RST ", %" PRIu32 ")", noop_data1->u);
             break;
 
         case 2:

--- a/src/libgbd/gbd.c
+++ b/src/libgbd/gbd.c
@@ -3100,7 +3100,7 @@ chk_DPLoadSync(gfx_state_t *state)
 static int
 chk_DPTileSync(gfx_state_t *state)
 {
-    // tilesync will sync all tile descrptiors, it's hard to knowif a tilesync is superfluous
+    // tilesync will sync all tile descriptors, it's hard to know if a tilesync is superfluous
     // (doesn't help that it's not clear when a tilesync should even be done)
 
     // ARG_CHECK(state, state->tile_busy[], GW_SUPERFLUOUS_TILESYNC);


### PR DESCRIPTION
Fix CI images with --print-textures

This builds on top of #12 so merge that other one first

----------

Example:

Given this data:

<details>

```c
#include <stdint.h>

#define F3DEX_GBI_2
#include "../libgfxd/gbi.h"

#define gsDma1p(c, s, l, p)                                                             \
    {                                                                                   \
        ((((c) & 0xFF) << 24) | (((p) & 0xFF) << 16) | (l & 0xFFFF)), (unsigned int)(s) \
    }

#define gsDPNoOpHere(file, line)        gsDma1p(G_NOOP, file, line, 1)
#define gsDPNoOpString(data, n)         gsDma1p(G_NOOP, data, n, 2)
#define gsDPNoOpWord(data, n)           gsDma1p(G_NOOP, data, n, 3)
#define gsDPNoOpFloat(data, n)          gsDma1p(G_NOOP, data, n, 4)
#define gsDPNoOpQuiet()                 gsDma1p(G_NOOP, 0, 0, 5)
#define gsDPNoOpVerbose(n)              gsDma1p(G_NOOP, 0, n, 5)
#define gsDPNoOpCallBack(callback, arg) gsDma1p(G_NOOP, callback, arg, 6)
#define gsDPNoOpOpenDisp(file, line)    gsDma1p(G_NOOP, file, line, 7)
#define gsDPNoOpCloseDisp(file, line)   gsDma1p(G_NOOP, file, line, 8)
#define gsDPNoOpTag3(type, data, n)     gsDma1p(G_NOOP, data, n, type)

Gfx other_dlist[] = {
    gsDPNoOpHere("f3dex2.c", __LINE__),
    gsDPNoOpString("hello", 0x421),
    gsDPNoOpWord(0x42000000, 0x1234),
    gsDPNoOpFloat(0x87654321, 0),
    gsDPNoOpQuiet(),
    gsDPNoOpVerbose(1),
    gsDPNoOpCallBack(0x80000000, 0x789),
    gsDPNoOpOpenDisp("f3dex2.c", __LINE__),
    gsDPNoOpCloseDisp("f3dex2.c", __LINE__),
    // gsDPNoOpCloseDisp("f3dex2.c", __LINE__),
    gsDPNoOpTag3(0xC, 0x33333333, 0x4444),
    gsSPEndDisplayList(),
};

uint64_t tex[] = { 0xFF0000FF00FF00FF };

uint64_t pal_tex[] = { ((uint64_t)GPACK_RGBA5551(31, 0, 0, 1) << 48) | ((uint64_t)GPACK_RGBA5551(0, 31, 0, 1) << 32) |
                       ((uint64_t)GPACK_RGBA5551(0, 0, 31, 1) << 16) | ((uint64_t)GPACK_RGBA5551(31, 31, 31, 1) << 0) };

uint64_t ci4_tex[] = { 0x0123012300003210 };
uint64_t ci8_tex[] = { 0x0001000100010203 };

Gfx tex_dlist[] = {
    gsDPNoOpString("tex_dlist", 0),
    gsDPLoadTextureBlock(tex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 2, 1, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, 1, 0, 0, 0),
    gsSP1Triangle(0, 1, 2, 0),
    gsDPPipeSync(),
    gsDPSetTextureLUT(G_TT_RGBA16),
    gsDPNoOpString("ci4 with palette in slot 0", 0),
    gsDPLoadTLUT_pal16(0, pal_tex),
    gsDPLoadTextureBlock_4b(ci4_tex, G_IM_FMT_CI, 16, 1, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 3, 0,
                            0, 0),
    gsSP1Triangle(0, 1, 2, 0),
    gsDPPipeSync(),
    gsDPNoOpString("ci4 with palette in slot 3", 0),
    gsDPLoadTLUT_pal16(3, pal_tex),
    gsDPLoadTextureBlock_4b(ci4_tex, G_IM_FMT_CI, 16, 1, 3, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 3, 0,
                            0, 0),
    gsSP1Triangle(0, 1, 2, 0),
    gsDPPipeSync(),
    gsDPNoOpString("ci8", 0),
    gsDPLoadTLUT_pal256(pal_tex),
    gsDPLoadTextureBlock(ci8_tex, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 1, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, 3, 0, 0, 0),
    gsSP1Triangle(0, 1, 2, 0),
    gsDPPipeSync(),
    gsDPNoOpString("ci8 with palette load after texture load", 0),
    gsDPLoadTextureBlock(ci8_tex, G_IM_FMT_CI, G_IM_SIZ_8b, 8, 1, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, 3, 0, 0, 0),
    gsDPLoadTLUT_pal256(pal_tex),
    gsSPEndDisplayList(),
};

__attribute__((aligned(64))) uint8_t framebuffer[320 * 240 * 2];

Gfx data_dlist[] = {
    gsDPSetScissor(G_SC_NON_INTERLACE, 0, 0, 320, 240),
    gsDPSetColorImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, framebuffer),
    gsDPSetCombineMode(G_CC_PRIMITIVE, G_CC_PRIMITIVE),
    gsSPDisplayList(other_dlist),
    gsSPDisplayList(tex_dlist),
    gsSPEndDisplayList(),
};

void *data_ptr = data_dlist;
```

</details>

->

<img width="3000" height="1903" alt="image" src="https://github.com/user-attachments/assets/0dc8b7a0-54e1-4ff9-9cb8-f0bcffa6d82e" />
